### PR TITLE
[P1-5] Add new identity fields to ZhtpIdentity struct

### DIFF
--- a/examples/dao_wallet_demo.rs
+++ b/examples/dao_wallet_demo.rs
@@ -134,7 +134,8 @@ async fn main() -> Result<()> {
         60000, // 60K ZHTP (exceeds 50K limit)
         None,
         "Large investment (should fail)".to_string(),
-        creator_did_2.clone(),
+        Some(creator_did_2.clone()),
+        None,
     ) {
         Ok(_) => println!(" This should not happen!"),
         Err(e) => println!("Correctly blocked: {}", e),

--- a/src/did/document_generation.rs
+++ b/src/did/document_generation.rs
@@ -143,36 +143,36 @@ fn create_verification_methods(
     let mut methods = Vec::new();
     
     // Primary quantum-resistant authentication key
-    let primary_key_multibase = encode_public_key_multibase(&identity.public_key)?;
+    let primary_key_multibase = encode_public_key_multibase(&identity.public_key.as_bytes())?;
     methods.push(VerificationMethod {
         id: format!("{}#primary", did),
         verification_type: "PostQuantumSignature2024".to_string(),
         controller: did.to_string(),
         public_key_multibase: primary_key_multibase,
     });
-    
+
     // Authentication method
     methods.push(VerificationMethod {
         id: format!("{}#authentication", did),
         verification_type: "PostQuantumAuthentication2024".to_string(),
         controller: did.to_string(),
-        public_key_multibase: encode_public_key_multibase(&identity.public_key)?,
+        public_key_multibase: encode_public_key_multibase(&identity.public_key.as_bytes())?,
     });
-    
+
     // Assertion method for credentials
     methods.push(VerificationMethod {
         id: format!("{}#assertion", did),
         verification_type: "PostQuantumAssertion2024".to_string(),
         controller: did.to_string(),
-        public_key_multibase: encode_public_key_multibase(&identity.public_key)?,
+        public_key_multibase: encode_public_key_multibase(&identity.public_key.as_bytes())?,
     });
-    
+
     // Key agreement for encryption
     methods.push(VerificationMethod {
         id: format!("{}#keyAgreement", did),
         verification_type: "PostQuantumKeyAgreement2024".to_string(),
         controller: did.to_string(),
-        public_key_multibase: encode_public_key_multibase(&identity.public_key)?,
+        public_key_multibase: encode_public_key_multibase(&identity.public_key.as_bytes())?,
     });
     
     Ok(methods)

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -163,7 +163,7 @@ impl ZhtpIdentity {
         ownership_proof: ZeroKnowledgeProof,
     ) -> Result<Self> {
         // 1. Derive DID from public key (canonical)
-        let did = Self::generate_did(&public_key.dilithium_pk)?;
+        let did = Self::generate_did(&public_key)?;
 
         // 2. Derive ID from DID
         let id = Hash::from_bytes(&lib_crypto::hash_blake3(did.as_bytes()).to_vec());
@@ -177,7 +177,11 @@ impl ZhtpIdentity {
 
         // 5. Derive all secrets from master keypair (deterministic)
         let zk_identity_secret = Self::derive_zk_secret(&private_key.dilithium_sk)?;
-        let zk_credential_hash = Self::derive_credential_hash(&zk_identity_secret, age, jurisdiction.as_deref())?;
+        let zk_credential_hash = Self::derive_credential_hash(
+            &zk_identity_secret,
+            age.unwrap_or(25),
+            jurisdiction.as_deref().unwrap_or("US")
+        )?;
         let wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
         let dao_member_id = Self::derive_dao_member_id(&did)?;
 
@@ -236,11 +240,10 @@ impl ZhtpIdentity {
         })
     }
 
-    /// Generate canonical DID from Dilithium public key
-    /// Per spec: "did:zhtp:[hex(blake3(dilithium_pk))]"
-    fn generate_did(dilithium_pk: &[u8]) -> Result<String> {
-        let hash = lib_crypto::hash_blake3(dilithium_pk);
-        Ok(format!("did:zhtp:{}", hex::encode(hash)))
+    /// Generate canonical DID from PublicKey key_id
+    /// Per Issue #9 spec: "did:zhtp:{hex(public_key.key_id)}"
+    fn generate_did(public_key: &PublicKey) -> Result<String> {
+        Ok(format!("did:zhtp:{}", hex::encode(public_key.key_id)))
     }
 
     /// Derive ZK identity secret from private key
@@ -250,19 +253,20 @@ impl ZhtpIdentity {
         Ok(hash)
     }
 
-    /// Derive credential hash from secret + age + jurisdiction
-    /// Per spec: Blake3(secret + age + jurisdiction)
+    /// Derive credential hash from ZK secret, age, and jurisdiction
+    /// Per Issue #9 spec: Blake3("ZHTP_CREDENTIAL_V1:" + secret + age + jurisdiction_code)
+    /// - age: Required age value (no default)
+    /// - jurisdiction: Required jurisdiction code (no default)
     fn derive_credential_hash(
         secret: &[u8; 32],
-        age: Option<u64>,
-        jurisdiction: Option<&str>,
+        age: u64,
+        jurisdiction: &str,
     ) -> Result<[u8; 32]> {
-        let age_val = age.unwrap_or(25);
-        let juris_code = Self::jurisdiction_to_code(jurisdiction.unwrap_or("US"));
+        let juris_code = Self::jurisdiction_to_code(jurisdiction);
         let hash = lib_crypto::hash_blake3(&[
             b"ZHTP_CREDENTIAL_V1:",
             secret.as_slice(),
-            &age_val.to_le_bytes(),
+            &age.to_le_bytes(),
             &juris_code.to_le_bytes(),
         ].concat());
         Ok(hash)
@@ -314,7 +318,7 @@ impl ZhtpIdentity {
         let public_key = PublicKey::new(public_key_bytes);
 
         // Derive DID from public key (canonical)
-        let did = Self::generate_did(&public_key.dilithium_pk)?;
+        let did = Self::generate_did(&public_key)?;
 
         // Generate primary NodeId from DID + device
         let node_id = NodeId::from_did_device(&did, &primary_device)?;
@@ -325,7 +329,7 @@ impl ZhtpIdentity {
 
         // Derive all secrets from master keypair (deterministic)
         let zk_identity_secret = Self::derive_zk_secret(&private_key.dilithium_sk)?;
-        let zk_credential_hash = Self::derive_credential_hash(&zk_identity_secret, None, None)?;
+        let zk_credential_hash = Self::derive_credential_hash(&zk_identity_secret, 25, "US")?;
         let wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
         let dao_member_id = Self::derive_dao_member_id(&did)?;
 
@@ -414,8 +418,8 @@ impl ZhtpIdentity {
         self.zk_identity_secret = Self::derive_zk_secret(&private_key.dilithium_sk)?;
         self.zk_credential_hash = Self::derive_credential_hash(
             &self.zk_identity_secret,
-            self.age,
-            self.jurisdiction.as_deref()
+            self.age.unwrap_or(25),
+            self.jurisdiction.as_deref().unwrap_or("US")
         )?;
         self.wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
         self.validate_secrets_derived()?; // Validate after re-derivation

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -10,28 +10,16 @@ use crate::types::{IdentityId, IdentityType, CredentialType, IdentityProofParams
 use crate::credentials::ZkCredential;
 use crate::credentials::IdentityAttestation;
 
-/// SECURITY: Default functions for skipped deserialization fields
-/// These fields MUST be re-derived after deserialization using rederive_secrets()
-fn default_zk_secret() -> [u8; 32] {
-    [0u8; 32]
-}
-
-fn default_zk_hash() -> [u8; 32] {
-    [0u8; 32]
-}
-
-fn default_wallet_seed() -> [u8; 64] {
-    [0u8; 64]
-}
-
 /// ZHTP Identity with zero-knowledge privacy and integrated quantum wallet management
 ///
 /// ## Security Note on Deserialization
 /// The fields `zk_identity_secret`, `zk_credential_hash`, and `wallet_master_seed` are marked
-/// with `#[serde(skip)]` and CANNOT be deserialized. They will be zero-valued after
-/// deserialization and MUST be re-derived using `rederive_secrets()` with the private key.
+/// with `#[serde(skip)]` and will be ZERO after deserialization.
 ///
-/// **Always construct identities via `new()` or `from_legacy_fields()` for proper security.**
+/// **CRITICAL**: After deserialization, you MUST call `rederive_secrets(private_key)` before
+/// using the identity, or call `validate_secrets_derived()` to ensure secrets are present.
+///
+/// **Recommended**: Always construct identities via `new()` or `from_legacy_fields()` for proper security.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ZhtpIdentity {
     /// Unique identity identifier  
@@ -39,7 +27,6 @@ pub struct ZhtpIdentity {
     /// Identity type
     pub identity_type: IdentityType,
     /// Decentralized Identifier (DID)
-    #[serde(default)]
     pub did: String,
     /// Public key for verification (lib-crypto type)
     pub public_key: PublicKey,
@@ -47,13 +34,10 @@ pub struct ZhtpIdentity {
     #[serde(skip)]
     pub private_key: Option<PrivateKey>,
     /// Primary device NodeId
-    #[serde(default)]
     pub node_id: NodeId,
     /// Device name to NodeId mapping
-    #[serde(default)]
     pub device_node_ids: HashMap<String, NodeId>,
     /// Primary device name
-    #[serde(default)]
     pub primary_device: String,
     /// Zero-knowledge proof of identity ownership
     pub ownership_proof: ZeroKnowledgeProof,
@@ -89,7 +73,7 @@ pub struct ZhtpIdentity {
     #[serde(skip)]
     pub encrypted_master_seed: Option<Vec<u8>>,
     /// Next wallet derivation index for HD wallets
-    #[serde(skip)]
+    #[serde(skip, default)]
     pub next_wallet_index: u32,
     /// Optional password hash for DID-level authentication
     #[serde(skip)]
@@ -98,35 +82,34 @@ pub struct ZhtpIdentity {
     #[serde(skip)]
     pub master_seed_phrase: Option<crate::recovery::RecoveryPhrase>,
     /// Zero-knowledge identity secret (32 bytes)
-    /// Derived from private key - never serialized, cannot be deserialized
-    /// SECURITY: Must construct via new() or from_legacy_fields() to derive properly
-    /// After deserialization, call rederive_secrets() to restore proper values
-    #[serde(skip, default = "default_zk_secret")]
+    /// Derived from private key - never serialized
+    /// SECURITY: Always zero after deserialization - MUST call rederive_secrets()
+    #[serde(skip)]
     pub zk_identity_secret: [u8; 32],
     /// Zero-knowledge credential hash (32 bytes)
-    /// Derived from secret + age + jurisdiction - skipped in serialization
-    /// SECURITY: Must construct via new() or from_legacy_fields() to derive properly
-    /// After deserialization, call rederive_secrets() to restore proper values
-    #[serde(skip, default = "default_zk_hash")]
+    /// Derived from secret + age + jurisdiction
+    /// SECURITY: Always zero after deserialization - MUST call rederive_secrets()
+    #[serde(skip)]
     pub zk_credential_hash: [u8; 32],
     /// Wallet master seed (64 bytes - raw derived seed)
-    /// Derived from private key - never serialized, cannot be deserialized
-    /// SECURITY: Must construct via new() or from_legacy_fields() to derive properly
-    /// After deserialization, call rederive_secrets() to restore proper values
+    /// Derived from private key - never serialized
+    /// SECURITY: Always zero after deserialization - MUST call rederive_secrets()
     #[serde(skip, default = "default_wallet_seed")]
     pub wallet_master_seed: [u8; 64],
     /// DAO member identifier
-    #[serde(default)]
     pub dao_member_id: String,
     /// DAO voting power
-    #[serde(default)]
     pub dao_voting_power: u64,
     /// Citizenship verification status
-    #[serde(default)]
     pub citizenship_verified: bool,
     /// Jurisdiction (optional)
-    #[serde(default)]
     pub jurisdiction: Option<String>,
+}
+
+// Default functions for deserialization of secret fields
+// SECURITY: These explicitly return zero values - secrets MUST be re-derived after deserialization
+fn default_wallet_seed() -> [u8; 64] {
+    [0u8; 64]
 }
 
 impl PartialEq for ZhtpIdentity {

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -3,12 +3,17 @@
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use lib_crypto::Hash;
+use lib_crypto::{Hash, PublicKey, PrivateKey};
 use lib_proofs::ZeroKnowledgeProof;
 
-use crate::types::{IdentityId, IdentityType, CredentialType, IdentityProofParams, IdentityVerification, AccessLevel};
+use crate::types::{IdentityId, IdentityType, CredentialType, IdentityProofParams, IdentityVerification, AccessLevel, NodeId};
 use crate::credentials::ZkCredential;
 use crate::credentials::IdentityAttestation;
+
+/// Default function for wallet_master_seed
+fn default_wallet_seed() -> [u8; 64] {
+    [0u8; 64]
+}
 
 /// ZHTP Identity with zero-knowledge privacy and integrated quantum wallet management
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,16 +22,31 @@ pub struct ZhtpIdentity {
     pub id: IdentityId,
     /// Identity type
     pub identity_type: IdentityType,
-    /// Public key for verification
-    pub public_key: Vec<u8>,
+    /// Decentralized Identifier (DID)
+    #[serde(default)]
+    pub did: String,
+    /// Public key for verification (lib-crypto type)
+    pub public_key: PublicKey,
+    /// Private key (sensitive - not serialized)
+    #[serde(skip)]
+    pub private_key: Option<PrivateKey>,
+    /// Primary device NodeId
+    #[serde(default)]
+    pub node_id: NodeId,
+    /// Device name to NodeId mapping
+    #[serde(default)]
+    pub device_node_ids: HashMap<String, NodeId>,
+    /// Primary device name
+    #[serde(default)]
+    pub primary_device: String,
     /// Zero-knowledge proof of identity ownership
     pub ownership_proof: ZeroKnowledgeProof,
     /// Associated credentials
     pub credentials: HashMap<CredentialType, ZkCredential>,
     /// Reputation score (0-1000)
-    pub reputation: u32,
+    pub reputation: u64,
     /// Current age (for age verification)
-    pub age: Option<u8>,
+    pub age: Option<u64>,
     /// Access level (for citizen benefits)
     pub access_level: AccessLevel,
     /// Identity metadata
@@ -61,6 +81,28 @@ pub struct ZhtpIdentity {
     /// Master seed phrase for identity recovery (20 words)
     #[serde(skip)]
     pub master_seed_phrase: Option<crate::recovery::RecoveryPhrase>,
+    /// Zero-knowledge identity secret (32 bytes)
+    #[serde(skip)]
+    #[serde(default)]
+    pub zk_identity_secret: [u8; 32],
+    /// Zero-knowledge credential hash (32 bytes)
+    #[serde(default)]
+    pub zk_credential_hash: [u8; 32],
+    /// Wallet master seed (64 bytes - raw derived seed)
+    #[serde(skip, default = "default_wallet_seed")]
+    pub wallet_master_seed: [u8; 64],
+    /// DAO member identifier
+    #[serde(default)]
+    pub dao_member_id: String,
+    /// DAO voting power
+    #[serde(default)]
+    pub dao_voting_power: u64,
+    /// Citizenship verification status
+    #[serde(default)]
+    pub citizenship_verified: bool,
+    /// Jurisdiction (optional)
+    #[serde(default)]
+    pub jurisdiction: Option<String>,
 }
 
 impl PartialEq for ZhtpIdentity {
@@ -73,21 +115,36 @@ impl ZhtpIdentity {
     /// Create a new ZHTP identity with integrated quantum wallet system
     pub fn new(
         identity_type: IdentityType,
-        public_key: Vec<u8>,
+        did: String,
+        public_key: PublicKey,
+        private_key: Option<PrivateKey>,
+        device_name: String,
         ownership_proof: ZeroKnowledgeProof,
     ) -> Result<Self> {
-        let id = Hash::from_bytes(&public_key);
+        let id = Hash::from_bytes(&public_key.as_bytes());
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
-        
+
+        // Create primary device NodeId
+        let node_id = NodeId::from_did_device(&did, &device_name)?;
+
+        // Initialize device mapping with primary device
+        let mut device_node_ids = HashMap::new();
+        device_node_ids.insert(device_name.clone(), node_id);
+
         // Create integrated wallet manager
         let wallet_manager = crate::wallets::WalletManager::new(id.clone());
-        
+
         Ok(ZhtpIdentity {
             id: id.clone(),
             identity_type,
+            did,
             public_key,
+            private_key,
+            node_id,
+            device_node_ids,
+            primary_device: device_name,
             ownership_proof,
             credentials: HashMap::new(),
             reputation: 0,
@@ -107,12 +164,82 @@ impl ZhtpIdentity {
             next_wallet_index: 0,
             password_hash: None,  // Set via PasswordManager
             master_seed_phrase: None,  // Set during identity creation
+            zk_identity_secret: [0u8; 32],  // Set during identity creation
+            zk_credential_hash: [0u8; 32],
+            wallet_master_seed: [0u8; 64],  // Derived from identity secrets
+            dao_member_id: String::new(),
+            dao_voting_power: 0,
+            citizenship_verified: false,
+            jurisdiction: None,
         })
     }
     
+    /// Create identity from legacy Vec<u8> public_key (for migration)
+    /// This provides default values for new fields
+    pub fn from_legacy_fields(
+        id: IdentityId,
+        identity_type: IdentityType,
+        public_key_bytes: Vec<u8>,
+        ownership_proof: ZeroKnowledgeProof,
+        wallet_manager: crate::wallets::WalletManager,
+    ) -> Result<Self> {
+        // Convert Vec<u8> to PublicKey
+        let public_key = PublicKey::new(public_key_bytes.clone());
+
+        // Generate temporary DID from public key hash
+        let did = format!("did:zhtp:{}", hex::encode(&public_key_bytes[..16]));
+
+        // Create default NodeId (will be properly set later)
+        let node_id = NodeId::from_did_device(&did, "default")?;
+
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs();
+
+        let mut device_node_ids = HashMap::new();
+        device_node_ids.insert("default".to_string(), node_id);
+
+        Ok(ZhtpIdentity {
+            id: id.clone(),
+            identity_type,
+            did,
+            public_key,
+            private_key: None,
+            node_id,
+            device_node_ids,
+            primary_device: "default".to_string(),
+            ownership_proof,
+            credentials: HashMap::new(),
+            reputation: 0,
+            age: None,
+            access_level: AccessLevel::default(),
+            metadata: HashMap::new(),
+            private_data_id: Some(id),
+            wallet_manager,
+            attestations: Vec::new(),
+            created_at: current_time,
+            last_active: current_time,
+            recovery_keys: Vec::new(),
+            did_document_hash: None,
+            owner_identity_id: None,
+            reward_wallet_id: None,
+            encrypted_master_seed: None,
+            next_wallet_index: 0,
+            password_hash: None,
+            master_seed_phrase: None,
+            zk_identity_secret: [0u8; 32],
+            zk_credential_hash: [0u8; 32],
+            wallet_master_seed: [0u8; 64],
+            dao_member_id: String::new(),
+            dao_voting_power: 0,
+            citizenship_verified: false,
+            jurisdiction: None,
+        })
+    }
+
     // Note: Wallet creation now done directly through WalletManager for consistency
     // Use identity.wallet_manager.create_wallet_with_seed_phrase() for proper seed phrase support
-    
+
     /// Get wallet by alias
     pub fn get_wallet(&self, alias: &str) -> Option<&crate::wallets::QuantumWallet> {
         self.wallet_manager.get_wallet_by_alias(alias)

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -10,17 +10,28 @@ use crate::types::{IdentityId, IdentityType, CredentialType, IdentityProofParams
 use crate::credentials::ZkCredential;
 use crate::credentials::IdentityAttestation;
 
-/// Default function for wallet_master_seed (only for deserialization)
-fn default_wallet_seed() -> [u8; 64] {
-    [0u8; 64]
-}
-
-/// Default function for zk_identity_secret (only for deserialization)
+/// SECURITY: Default functions for skipped deserialization fields
+/// These fields MUST be re-derived after deserialization using rederive_secrets()
 fn default_zk_secret() -> [u8; 32] {
     [0u8; 32]
 }
 
+fn default_zk_hash() -> [u8; 32] {
+    [0u8; 32]
+}
+
+fn default_wallet_seed() -> [u8; 64] {
+    [0u8; 64]
+}
+
 /// ZHTP Identity with zero-knowledge privacy and integrated quantum wallet management
+///
+/// ## Security Note on Deserialization
+/// The fields `zk_identity_secret`, `zk_credential_hash`, and `wallet_master_seed` are marked
+/// with `#[serde(skip)]` and CANNOT be deserialized. They will be zero-valued after
+/// deserialization and MUST be re-derived using `rederive_secrets()` with the private key.
+///
+/// **Always construct identities via `new()` or `from_legacy_fields()` for proper security.**
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ZhtpIdentity {
     /// Unique identity identifier  
@@ -87,14 +98,21 @@ pub struct ZhtpIdentity {
     #[serde(skip)]
     pub master_seed_phrase: Option<crate::recovery::RecoveryPhrase>,
     /// Zero-knowledge identity secret (32 bytes)
-    /// Derived from private key - never serialized for security
+    /// Derived from private key - never serialized, cannot be deserialized
+    /// SECURITY: Must construct via new() or from_legacy_fields() to derive properly
+    /// After deserialization, call rederive_secrets() to restore proper values
     #[serde(skip, default = "default_zk_secret")]
     pub zk_identity_secret: [u8; 32],
     /// Zero-knowledge credential hash (32 bytes)
-    /// Derived from secret + age + jurisdiction
+    /// Derived from secret + age + jurisdiction - skipped in serialization
+    /// SECURITY: Must construct via new() or from_legacy_fields() to derive properly
+    /// After deserialization, call rederive_secrets() to restore proper values
+    #[serde(skip, default = "default_zk_hash")]
     pub zk_credential_hash: [u8; 32],
     /// Wallet master seed (64 bytes - raw derived seed)
-    /// Derived from private key - never serialized for security
+    /// Derived from private key - never serialized, cannot be deserialized
+    /// SECURITY: Must construct via new() or from_legacy_fields() to derive properly
+    /// After deserialization, call rederive_secrets() to restore proper values
     #[serde(skip, default = "default_wallet_seed")]
     pub wallet_master_seed: [u8; 64],
     /// DAO member identifier
@@ -129,6 +147,7 @@ impl ZhtpIdentity {
         primary_device: String,
         age: Option<u64>,
         jurisdiction: Option<String>,
+        citizenship_verified: bool,
         ownership_proof: ZeroKnowledgeProof,
     ) -> Result<Self> {
         // 1. Derive DID from public key (canonical)
@@ -150,8 +169,12 @@ impl ZhtpIdentity {
         let wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
         let dao_member_id = Self::derive_dao_member_id(&did)?;
 
-        // 6. Set initial DAO voting power (citizens = 1, verified humans = 10)
+        // 6. Set initial DAO voting power per spec:
+        // - Verified citizens: 10
+        // - Unverified humans: 1
+        // - Other types (Device, Organization, etc.): 0
         let dao_voting_power = match identity_type {
+            IdentityType::Human if citizenship_verified => 10,
             IdentityType::Human => 1,
             _ => 0,
         };
@@ -196,7 +219,7 @@ impl ZhtpIdentity {
             wallet_master_seed,
             dao_member_id,
             dao_voting_power,
-            citizenship_verified: false,
+            citizenship_verified,
             jurisdiction,
         })
     }
@@ -334,6 +357,28 @@ impl ZhtpIdentity {
             citizenship_verified: false,
             jurisdiction: None,
         })
+    }
+
+    /// Re-derive cryptographic secrets after deserialization
+    ///
+    /// SECURITY: This method MUST be called after deserializing a ZhtpIdentity from storage.
+    /// The secrets (zk_identity_secret, zk_credential_hash, wallet_master_seed) are never
+    /// serialized and will be zero-valued after deserialization.
+    ///
+    /// # Arguments
+    /// * `private_key` - The private key to derive secrets from
+    ///
+    /// # Returns
+    /// Ok(()) if secrets were successfully re-derived, Err if derivation failed
+    pub fn rederive_secrets(&mut self, private_key: &PrivateKey) -> Result<()> {
+        self.zk_identity_secret = Self::derive_zk_secret(&private_key.dilithium_sk)?;
+        self.zk_credential_hash = Self::derive_credential_hash(
+            &self.zk_identity_secret,
+            self.age,
+            self.jurisdiction.as_deref()
+        )?;
+        self.wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
+        Ok(())
     }
 
     // Note: Wallet creation now done directly through WalletManager for consistency

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -1,7 +1,7 @@
 //! ZHTP Identity implementation from the original identity.rs
 
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use lib_crypto::{Hash, PublicKey, PrivateKey};
 use lib_proofs::ZeroKnowledgeProof;
@@ -26,10 +26,8 @@ use crate::credentials::IdentityAttestation;
 ///
 /// ### Unsafe Deserialization (NOT RECOMMENDED)
 /// ```ignore
-/// // ✗ UNSAFE: Secrets will be zero - must manually call rederive_secrets()
-/// let mut identity: ZhtpIdentity = serde_json::from_str(&json_data)?;
-/// identity.rederive_secrets(&private_key)?;  // MUST call this!
-/// identity.validate_secrets_derived()?;      // Verify secrets are valid
+/// // ✗ UNSAFE: Direct Deserialize is forbidden; use from_serialized instead.
+/// // Attempting direct deserialization will fail.
 /// ```
 ///
 /// ### Construction (Preferred)
@@ -40,7 +38,7 @@ use crate::credentials::IdentityAttestation;
 ///     primary_device, age, jurisdiction, citizenship_verified, ownership_proof
 /// )?;
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ZhtpIdentity {
     /// Unique identity identifier  
     pub id: IdentityId,
@@ -135,6 +133,17 @@ fn default_wallet_seed() -> [u8; 64] {
 impl PartialEq for ZhtpIdentity {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
+    }
+}
+
+impl<'de> Deserialize<'de> for ZhtpIdentity {
+    fn deserialize<D>(_deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Err(serde::de::Error::custom(
+            "Direct deserialization of ZhtpIdentity is forbidden. Use ZhtpIdentity::from_serialized(private_key) to safely re-derive secrets.",
+        ))
     }
 }
 
@@ -431,11 +440,112 @@ impl ZhtpIdentity {
     /// let restored = ZhtpIdentity::from_serialized(&json, &private_key)?;
     /// ```
     pub fn from_serialized(data: &str, private_key: &PrivateKey) -> Result<Self> {
-        let mut identity: ZhtpIdentity = serde_json::from_str(data)
-            .map_err(|e| anyhow!("Failed to deserialize identity: {}", e))?;
+        // SECURITY: Direct Deserialize is forbidden; parse manually into an intermediate
+        let raw: serde_json::Value = serde_json::from_str(data)
+            .map_err(|e| anyhow!("Failed to parse identity JSON: {}", e))?;
 
-        // SECURITY: Automatically re-derive secrets after deserialization
-        identity.rederive_secrets(private_key)?;
+        // Manually extract required fields
+        let public_key: PublicKey = serde_json::from_value(
+            raw.get("public_key")
+                .cloned()
+                .ok_or_else(|| anyhow!("Missing public_key"))?,
+        ).map_err(|e| anyhow!("Invalid public_key: {}", e))?;
+
+        let identity_type: IdentityType = serde_json::from_value(
+            raw.get("identity_type")
+                .cloned()
+                .ok_or_else(|| anyhow!("Missing identity_type"))?,
+        ).map_err(|e| anyhow!("Invalid identity_type: {}", e))?;
+
+        let primary_device = raw.get("primary_device")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing primary_device"))?
+            .to_string();
+
+        let age = raw.get("age").and_then(|v| v.as_u64());
+        let jurisdiction = raw.get("jurisdiction").and_then(|v| v.as_str()).map(|s| s.to_string());
+        let citizenship_verified = raw.get("citizenship_verified").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        // Optional fields
+        let credentials: HashMap<CredentialType, ZkCredential> = serde_json::from_value(
+            raw.get("credentials").cloned().unwrap_or_else(|| serde_json::json!({}))
+        ).unwrap_or_default();
+        let metadata: HashMap<String, String> = serde_json::from_value(
+            raw.get("metadata").cloned().unwrap_or_else(|| serde_json::json!({}))
+        ).unwrap_or_default();
+        let attestations: Vec<IdentityAttestation> = serde_json::from_value(
+            raw.get("attestations").cloned().unwrap_or_else(|| serde_json::json!([]))
+        ).unwrap_or_default();
+
+        // Rebuild via new() to ensure derivations are correct
+        let mut identity = ZhtpIdentity::new(
+            identity_type,
+            public_key,
+            private_key.clone(),
+            primary_device,
+            age,
+            jurisdiction,
+            citizenship_verified,
+            ZeroKnowledgeProof {
+                proof_system: raw.get("ownership_proof").and_then(|v| v.get("proof_system")).and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+                proof_data: raw.get("ownership_proof").and_then(|v| v.get("proof_data")).and_then(|v| v.as_array()).map(|arr| arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect()).unwrap_or_default(),
+                public_inputs: raw.get("ownership_proof").and_then(|v| v.get("public_inputs")).and_then(|v| v.as_array()).map(|arr| arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect()).unwrap_or_default(),
+                verification_key: raw.get("ownership_proof").and_then(|v| v.get("verification_key")).and_then(|v| v.as_array()).map(|arr| arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect()).unwrap_or_default(),
+                plonky2_proof: None,
+                proof: raw.get("ownership_proof").and_then(|v| v.get("proof")).and_then(|v| v.as_array()).map(|arr| arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect()).unwrap_or_default(),
+            },
+        )?;
+
+        // Restore all non-derived fields from serialized data
+        identity.credentials = credentials;
+        identity.metadata = metadata;
+        identity.attestations = attestations;
+
+        // Restore state fields
+        if let Some(reputation) = raw.get("reputation").and_then(|v| v.as_u64()) {
+            identity.reputation = reputation;
+        }
+        if let Some(access_level) = raw.get("access_level") {
+            if let Ok(level) = serde_json::from_value(access_level.clone()) {
+                identity.access_level = level;
+            }
+        }
+        if let Some(private_data_id) = raw.get("private_data_id") {
+            if let Ok(id) = serde_json::from_value(private_data_id.clone()) {
+                identity.private_data_id = id;
+            }
+        }
+        if let Some(wallet_manager) = raw.get("wallet_manager") {
+            if let Ok(manager) = serde_json::from_value(wallet_manager.clone()) {
+                identity.wallet_manager = manager;
+            }
+        }
+        if let Some(created_at) = raw.get("created_at").and_then(|v| v.as_u64()) {
+            identity.created_at = created_at;
+        }
+        if let Some(last_active) = raw.get("last_active").and_then(|v| v.as_u64()) {
+            identity.last_active = last_active;
+        }
+        if let Some(recovery_keys) = raw.get("recovery_keys") {
+            if let Ok(keys) = serde_json::from_value(recovery_keys.clone()) {
+                identity.recovery_keys = keys;
+            }
+        }
+        if let Some(did_document_hash) = raw.get("did_document_hash") {
+            if let Ok(hash) = serde_json::from_value(did_document_hash.clone()) {
+                identity.did_document_hash = hash;
+            }
+        }
+        if let Some(owner_identity_id) = raw.get("owner_identity_id") {
+            if let Ok(id) = serde_json::from_value(owner_identity_id.clone()) {
+                identity.owner_identity_id = id;
+            }
+        }
+        if let Some(reward_wallet_id) = raw.get("reward_wallet_id") {
+            if let Ok(id) = serde_json::from_value(reward_wallet_id.clone()) {
+                identity.reward_wallet_id = id;
+            }
+        }
 
         Ok(identity)
     }

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -10,9 +10,14 @@ use crate::types::{IdentityId, IdentityType, CredentialType, IdentityProofParams
 use crate::credentials::ZkCredential;
 use crate::credentials::IdentityAttestation;
 
-/// Default function for wallet_master_seed
+/// Default function for wallet_master_seed (only for deserialization)
 fn default_wallet_seed() -> [u8; 64] {
     [0u8; 64]
+}
+
+/// Default function for zk_identity_secret (only for deserialization)
+fn default_zk_secret() -> [u8; 32] {
+    [0u8; 32]
 }
 
 /// ZHTP Identity with zero-knowledge privacy and integrated quantum wallet management
@@ -82,13 +87,14 @@ pub struct ZhtpIdentity {
     #[serde(skip)]
     pub master_seed_phrase: Option<crate::recovery::RecoveryPhrase>,
     /// Zero-knowledge identity secret (32 bytes)
-    #[serde(skip)]
-    #[serde(default)]
+    /// Derived from private key - never serialized for security
+    #[serde(skip, default = "default_zk_secret")]
     pub zk_identity_secret: [u8; 32],
     /// Zero-knowledge credential hash (32 bytes)
-    #[serde(default)]
+    /// Derived from secret + age + jurisdiction
     pub zk_credential_hash: [u8; 32],
     /// Wallet master seed (64 bytes - raw derived seed)
+    /// Derived from private key - never serialized for security
     #[serde(skip, default = "default_wallet_seed")]
     pub wallet_master_seed: [u8; 64],
     /// DAO member identifier
@@ -112,26 +118,47 @@ impl PartialEq for ZhtpIdentity {
 }
 
 impl ZhtpIdentity {
-    /// Create a new ZHTP identity with integrated quantum wallet system
+    /// Create a new ZHTP identity with properly derived fields per architecture spec
+    ///
+    /// All cryptographic fields (DID, secrets, seeds) are deterministically derived
+    /// from the master keypair according to ARCHITECTURE_CONSOLIDATION.md specification.
     pub fn new(
         identity_type: IdentityType,
-        did: String,
         public_key: PublicKey,
-        private_key: Option<PrivateKey>,
-        device_name: String,
+        private_key: PrivateKey,  // Required for proper derivation
+        primary_device: String,
+        age: Option<u64>,
+        jurisdiction: Option<String>,
         ownership_proof: ZeroKnowledgeProof,
     ) -> Result<Self> {
-        let id = Hash::from_bytes(&public_key.as_bytes());
+        // 1. Derive DID from public key (canonical)
+        let did = Self::generate_did(&public_key.dilithium_pk)?;
+
+        // 2. Derive ID from DID
+        let id = Hash::from_bytes(&lib_crypto::hash_blake3(did.as_bytes()).to_vec());
+
+        // 3. Generate primary NodeId from DID + device
+        let node_id = NodeId::from_did_device(&did, &primary_device)?;
+
+        // 4. Initialize device mapping with primary device
+        let mut device_node_ids = HashMap::new();
+        device_node_ids.insert(primary_device.clone(), node_id);
+
+        // 5. Derive all secrets from master keypair (deterministic)
+        let zk_identity_secret = Self::derive_zk_secret(&private_key.dilithium_sk)?;
+        let zk_credential_hash = Self::derive_credential_hash(&zk_identity_secret, age, jurisdiction.as_deref())?;
+        let wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
+        let dao_member_id = Self::derive_dao_member_id(&did)?;
+
+        // 6. Set initial DAO voting power (citizens = 1, verified humans = 10)
+        let dao_voting_power = match identity_type {
+            IdentityType::Human => 1,
+            _ => 0,
+        };
+
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
-
-        // Create primary device NodeId
-        let node_id = NodeId::from_did_device(&did, &device_name)?;
-
-        // Initialize device mapping with primary device
-        let mut device_node_ids = HashMap::new();
-        device_node_ids.insert(device_name.clone(), node_id);
 
         // Create integrated wallet manager
         let wallet_manager = crate::wallets::WalletManager::new(id.clone());
@@ -141,73 +168,145 @@ impl ZhtpIdentity {
             identity_type,
             did,
             public_key,
-            private_key,
+            private_key: Some(private_key),
             node_id,
             device_node_ids,
-            primary_device: device_name,
+            primary_device,
             ownership_proof,
             credentials: HashMap::new(),
             reputation: 0,
-            age: None,
+            age,
             access_level: AccessLevel::default(),
             metadata: HashMap::new(),
-            private_data_id: Some(id.clone()),
+            private_data_id: Some(id),
             wallet_manager,
             attestations: Vec::new(),
             created_at: current_time,
             last_active: current_time,
             recovery_keys: Vec::new(),
             did_document_hash: None,
-            owner_identity_id: None,  // User identities have no owner
-            reward_wallet_id: None,    // User identities don't need this (nodes do)
-            encrypted_master_seed: None,  // Optional HD wallet feature
+            owner_identity_id: None,
+            reward_wallet_id: None,
+            encrypted_master_seed: None,
             next_wallet_index: 0,
-            password_hash: None,  // Set via PasswordManager
-            master_seed_phrase: None,  // Set during identity creation
-            zk_identity_secret: [0u8; 32],  // Set during identity creation
-            zk_credential_hash: [0u8; 32],
-            wallet_master_seed: [0u8; 64],  // Derived from identity secrets
-            dao_member_id: String::new(),
-            dao_voting_power: 0,
+            password_hash: None,
+            master_seed_phrase: None,
+            zk_identity_secret,
+            zk_credential_hash,
+            wallet_master_seed,
+            dao_member_id,
+            dao_voting_power,
             citizenship_verified: false,
-            jurisdiction: None,
+            jurisdiction,
         })
+    }
+
+    /// Generate canonical DID from Dilithium public key
+    /// Per spec: "did:zhtp:[hex(blake3(dilithium_pk))]"
+    fn generate_did(dilithium_pk: &[u8]) -> Result<String> {
+        let hash = lib_crypto::hash_blake3(dilithium_pk);
+        Ok(format!("did:zhtp:{}", hex::encode(hash)))
+    }
+
+    /// Derive ZK identity secret from private key
+    /// Per spec: Blake3("ZHTP_ZK_SECRET_V1:" + dilithium_private_key)
+    fn derive_zk_secret(dilithium_sk: &[u8]) -> Result<[u8; 32]> {
+        let hash = lib_crypto::hash_blake3(&[b"ZHTP_ZK_SECRET_V1:", dilithium_sk].concat());
+        Ok(hash)
+    }
+
+    /// Derive credential hash from secret + age + jurisdiction
+    /// Per spec: Blake3(secret + age + jurisdiction)
+    fn derive_credential_hash(
+        secret: &[u8; 32],
+        age: Option<u64>,
+        jurisdiction: Option<&str>,
+    ) -> Result<[u8; 32]> {
+        let age_val = age.unwrap_or(25);
+        let juris_code = Self::jurisdiction_to_code(jurisdiction.unwrap_or("US"));
+        let hash = lib_crypto::hash_blake3(&[
+            b"ZHTP_CREDENTIAL_V1:",
+            secret.as_slice(),
+            &age_val.to_le_bytes(),
+            &juris_code.to_le_bytes(),
+        ].concat());
+        Ok(hash)
+    }
+
+    /// Derive wallet master seed using Blake3 XOF
+    /// Per spec: Blake3_XOF("ZHTP_WALLET_SEED_V1:" + dilithium_private_key)
+    fn derive_wallet_seed(dilithium_sk: &[u8]) -> Result<[u8; 64]> {
+        let mut output = [0u8; 64];
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"ZHTP_WALLET_SEED_V1:");
+        hasher.update(dilithium_sk);
+        let mut reader = hasher.finalize_xof();
+        reader.fill(&mut output);
+        Ok(output)
+    }
+
+    /// Derive DAO member ID from DID
+    /// Per spec: Blake3("DAO:" + DID)
+    fn derive_dao_member_id(did: &str) -> Result<String> {
+        let hash = lib_crypto::hash_blake3(format!("DAO:{}", did).as_bytes());
+        Ok(hex::encode(hash))
+    }
+
+    /// Convert jurisdiction to numeric code (ISO 3166-1)
+    fn jurisdiction_to_code(jurisdiction: &str) -> u64 {
+        match jurisdiction {
+            "US" => 840,
+            "CA" => 124,
+            "GB" => 826,
+            "DE" => 276,
+            "FR" => 250,
+            _ => 840,  // Default to US
+        }
     }
     
     /// Create identity from legacy Vec<u8> public_key (for migration)
-    /// This provides default values for new fields
+    /// Now properly derives all fields from keypair per architecture spec
     pub fn from_legacy_fields(
         id: IdentityId,
         identity_type: IdentityType,
         public_key_bytes: Vec<u8>,
+        private_key: PrivateKey,
+        primary_device: String,
         ownership_proof: ZeroKnowledgeProof,
         wallet_manager: crate::wallets::WalletManager,
     ) -> Result<Self> {
         // Convert Vec<u8> to PublicKey
-        let public_key = PublicKey::new(public_key_bytes.clone());
+        let public_key = PublicKey::new(public_key_bytes);
 
-        // Generate temporary DID from public key hash
-        let did = format!("did:zhtp:{}", hex::encode(&public_key_bytes[..16]));
+        // Derive DID from public key (canonical)
+        let did = Self::generate_did(&public_key.dilithium_pk)?;
 
-        // Create default NodeId (will be properly set later)
-        let node_id = NodeId::from_did_device(&did, "default")?;
+        // Generate primary NodeId from DID + device
+        let node_id = NodeId::from_did_device(&did, &primary_device)?;
+
+        // Initialize device mapping
+        let mut device_node_ids = HashMap::new();
+        device_node_ids.insert(primary_device.clone(), node_id);
+
+        // Derive all secrets from master keypair (deterministic)
+        let zk_identity_secret = Self::derive_zk_secret(&private_key.dilithium_sk)?;
+        let zk_credential_hash = Self::derive_credential_hash(&zk_identity_secret, None, None)?;
+        let wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
+        let dao_member_id = Self::derive_dao_member_id(&did)?;
 
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
-
-        let mut device_node_ids = HashMap::new();
-        device_node_ids.insert("default".to_string(), node_id);
 
         Ok(ZhtpIdentity {
             id: id.clone(),
             identity_type,
             did,
             public_key,
-            private_key: None,
+            private_key: Some(private_key),
             node_id,
             device_node_ids,
-            primary_device: "default".to_string(),
+            primary_device,
             ownership_proof,
             credentials: HashMap::new(),
             reputation: 0,
@@ -227,10 +326,10 @@ impl ZhtpIdentity {
             next_wallet_index: 0,
             password_hash: None,
             master_seed_phrase: None,
-            zk_identity_secret: [0u8; 32],
-            zk_credential_hash: [0u8; 32],
-            wallet_master_seed: [0u8; 64],
-            dao_member_id: String::new(),
+            zk_identity_secret,
+            zk_credential_hash,
+            wallet_master_seed,
+            dao_member_id,
             dao_voting_power: 0,
             citizenship_verified: false,
             jurisdiction: None,

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -12,14 +12,34 @@ use crate::credentials::IdentityAttestation;
 
 /// ZHTP Identity with zero-knowledge privacy and integrated quantum wallet management
 ///
-/// ## Security Note on Deserialization
-/// The fields `zk_identity_secret`, `zk_credential_hash`, and `wallet_master_seed` are marked
-/// with `#[serde(skip)]` and will be ZERO after deserialization.
+/// ## Security-Critical Deserialization Requirements
 ///
-/// **CRITICAL**: After deserialization, you MUST call `rederive_secrets(private_key)` before
-/// using the identity, or call `validate_secrets_derived()` to ensure secrets are present.
+/// **DANGER**: Direct use of `serde_json::from_str()` or `Deserialize` produces identities
+/// with ZERO-VALUED cryptographic secrets. Using such identities without re-derivation is a
+/// CRITICAL SECURITY VULNERABILITY.
 ///
-/// **Recommended**: Always construct identities via `new()` or `from_legacy_fields()` for proper security.
+/// ### Safe Deserialization (REQUIRED)
+/// ```ignore
+/// // ✓ SAFE: Use from_serialized() which enforces re-derivation
+/// let identity = ZhtpIdentity::from_serialized(&json_data, &private_key)?;
+/// ```
+///
+/// ### Unsafe Deserialization (NOT RECOMMENDED)
+/// ```ignore
+/// // ✗ UNSAFE: Secrets will be zero - must manually call rederive_secrets()
+/// let mut identity: ZhtpIdentity = serde_json::from_str(&json_data)?;
+/// identity.rederive_secrets(&private_key)?;  // MUST call this!
+/// identity.validate_secrets_derived()?;      // Verify secrets are valid
+/// ```
+///
+/// ### Construction (Preferred)
+/// Always prefer `new()` or `from_legacy_fields()` which properly derive all secrets:
+/// ```ignore
+/// let identity = ZhtpIdentity::new(
+///     identity_type, public_key, private_key,
+///     primary_device, age, jurisdiction, citizenship_verified, ownership_proof
+/// )?;
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ZhtpIdentity {
     /// Unique identity identifier  
@@ -389,7 +409,35 @@ impl ZhtpIdentity {
             self.jurisdiction.as_deref()
         )?;
         self.wallet_master_seed = Self::derive_wallet_seed(&private_key.dilithium_sk)?;
+        self.validate_secrets_derived()?; // Validate after re-derivation
         Ok(())
+    }
+
+    /// Safe deserialization helper that requires re-derivation
+    ///
+    /// Use this instead of direct deserialization to ensure secrets are properly derived.
+    ///
+    /// # Arguments
+    /// * `data` - Serialized identity data (JSON string)
+    /// * `private_key` - Private key to derive secrets from
+    ///
+    /// # Returns
+    /// Ok(identity) with properly derived secrets, or Err if deserialization/derivation failed
+    ///
+    /// # Example
+    /// ```ignore
+    /// let json = serde_json::to_string(&identity)?;
+    /// // Later...
+    /// let restored = ZhtpIdentity::from_serialized(&json, &private_key)?;
+    /// ```
+    pub fn from_serialized(data: &str, private_key: &PrivateKey) -> Result<Self> {
+        let mut identity: ZhtpIdentity = serde_json::from_str(data)
+            .map_err(|e| anyhow!("Failed to deserialize identity: {}", e))?;
+
+        // SECURITY: Automatically re-derive secrets after deserialization
+        identity.rederive_secrets(private_key)?;
+
+        Ok(identity)
     }
 
     // Note: Wallet creation now done directly through WalletManager for consistency

--- a/src/identity/lib_identity.rs
+++ b/src/identity/lib_identity.rs
@@ -359,6 +359,34 @@ impl ZhtpIdentity {
         })
     }
 
+    /// Check if cryptographic secrets have been properly derived (not zero-valued)
+    ///
+    /// SECURITY: This should be called after deserialization to ensure secrets were re-derived.
+    /// Zero-valued secrets indicate the identity was deserialized but rederive_secrets() was not called.
+    ///
+    /// # Returns
+    /// true if all secrets are non-zero (properly derived), false if any are zero
+    pub fn is_secrets_derived(&self) -> bool {
+        self.zk_identity_secret != [0u8; 32]
+            && self.zk_credential_hash != [0u8; 32]
+            && self.wallet_master_seed != [0u8; 64]
+    }
+
+    /// Validate that secrets are properly derived, returning an error if not
+    ///
+    /// SECURITY: Use this to enforce that secrets are derived before use.
+    ///
+    /// # Returns
+    /// Ok(()) if secrets are properly derived, Err if any are zero-valued
+    pub fn validate_secrets_derived(&self) -> Result<()> {
+        if !self.is_secrets_derived() {
+            return Err(anyhow!(
+                "Identity has zero-valued secrets - must call rederive_secrets() after deserialization"
+            ));
+        }
+        Ok(())
+    }
+
     /// Re-derive cryptographic secrets after deserialization
     ///
     /// SECURITY: This method MUST be called after deserializing a ZhtpIdentity from storage.

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -101,34 +101,18 @@ impl IdentityManager {
         ).await?;
         
         // Create identity with citizen benefits
-        let identity = ZhtpIdentity {
-            id: id.clone(),
-            identity_type: IdentityType::Human,
-            public_key: public_key.clone(),
+        let mut identity = ZhtpIdentity::from_legacy_fields(
+            id.clone(),
+            IdentityType::Human,
+            public_key.clone(),
             ownership_proof,
-            credentials: HashMap::new(),
-            reputation: 500, // Citizens start with higher reputation
-            age: None,
-            access_level: AccessLevel::FullCitizen,
-            metadata: HashMap::new(),
-            private_data_id: Some(id.clone()),
             wallet_manager,
-            attestations: Vec::new(),
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)?
-                .as_secs(),
-            last_active: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)?
-                .as_secs(),
-            recovery_keys: vec![],
-            did_document_hash: None,
-            owner_identity_id: None,  // Humans don't have owners
-            reward_wallet_id: None,   // Humans don't need this (nodes do)
-            encrypted_master_seed: None,
-            next_wallet_index: 0,
-            password_hash: None,
-            master_seed_phrase: None,
-        };
+        )?;
+
+        // Set citizen-specific fields
+        identity.reputation = 500; // Citizens start with higher reputation
+        identity.access_level = AccessLevel::FullCitizen;
+        identity.citizenship_verified = true;
         
         // Store private data
         let private_data = PrivateIdentityData::new(
@@ -446,7 +430,7 @@ impl IdentityManager {
         
         // Generate public inputs (what can be verified publicly)
         let public_inputs = [
-            &identity.public_key,
+            identity.public_key.as_bytes().as_slice(),
             identity_id.0.as_slice(),
             &requirements.privacy_level.to_le_bytes()
         ].concat();
@@ -463,7 +447,7 @@ impl IdentityManager {
         
         // Create verification key from identity's public data
         let verification_key = lib_crypto::hash_blake3(&[
-            &identity.public_key,
+            identity.public_key.as_bytes().as_slice(),
             identity.created_at.to_le_bytes().as_slice(),
             identity.reputation.to_le_bytes().as_slice()
         ].concat());
@@ -519,12 +503,12 @@ impl IdentityManager {
         
         // Generate corresponding public key components
         let dilithium_pk = lib_crypto::hash_blake3(&[
-            &identity.public_key,
+            identity.public_key.as_bytes().as_slice(),
             b"dilithium".as_slice()
         ].concat()).to_vec();
-        
+
         let kyber_pk = lib_crypto::hash_blake3(&[
-            &identity.public_key,
+            identity.public_key.as_bytes().as_slice(),
             b"kyber".as_slice()
         ].concat()).to_vec();
         
@@ -566,34 +550,18 @@ impl IdentityManager {
         let (identity_id, private_key, public_key, seed) = recovery_manager.restore_from_phrase(&phrase_words).await?;
         
         // Create identity structure
-        let identity = ZhtpIdentity {
-            id: identity_id.clone(),
-            identity_type: IdentityType::Human,
-            public_key: public_key.clone(),
-            ownership_proof: self.generate_ownership_proof(&private_key, &public_key).await?,
-            credentials: HashMap::new(),
-            reputation: 100, // Base reputation for imported identity
-            age: None,
-            access_level: AccessLevel::FullCitizen, // Can be upgraded after verification
-            metadata: HashMap::new(),
-            private_data_id: Some(identity_id.clone()),
-            wallet_manager: crate::wallets::WalletManager::new(identity_id.clone()),
-            attestations: Vec::new(),
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)?
-                .as_secs(),
-            last_active: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)?
-                .as_secs(),
-            recovery_keys: vec![],
-            did_document_hash: None,
-            owner_identity_id: None,  // Humans don't have owners
-            reward_wallet_id: None,   // Humans don't need this (nodes do)
-            encrypted_master_seed: None,
-            next_wallet_index: 0,
-            password_hash: None,
-            master_seed_phrase: Some(crate::recovery::RecoveryPhrase::from_words(phrase_words.clone())?),
-        };
+        let mut identity = ZhtpIdentity::from_legacy_fields(
+            identity_id.clone(),
+            IdentityType::Human,
+            public_key.clone(),
+            self.generate_ownership_proof(&private_key, &public_key).await?,
+            crate::wallets::WalletManager::new(identity_id.clone()),
+        )?;
+
+        // Set import-specific fields
+        identity.reputation = 100; // Base reputation for imported identity
+        identity.access_level = AccessLevel::FullCitizen;
+        identity.master_seed_phrase = Some(crate::recovery::RecoveryPhrase::from_words(phrase_words.clone())?);
         
         // Create private data
         let private_data = PrivateIdentityData::new(

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -64,17 +64,24 @@ impl IdentityManager {
         economic_model: &mut EconomicModel,
     ) -> Result<CitizenshipResult> {
         // Generate quantum-resistant key pair
-        let (private_key, public_key) = self.generate_pq_keypair().await?;
-        
+        let (private_key_bytes, public_key) = self.generate_pq_keypair().await?;
+
+        // Wrap in PrivateKey struct
+        let private_key = lib_crypto::PrivateKey {
+            dilithium_sk: private_key_bytes.clone(),
+            kyber_sk: vec![],  // Not used in current implementation
+            master_seed: vec![],  // Derived separately
+        };
+
         // Generate identity seed
         let mut seed = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut seed);
-        
+
         // Create identity ID from public key
         let id = Hash::from_bytes(&blake3::hash(&public_key).as_bytes()[..32]);
-        
+
         // Generate ownership proof
-        let ownership_proof = self.generate_ownership_proof(&private_key, &public_key).await?;
+        let ownership_proof = self.generate_ownership_proof(&private_key_bytes, &public_key).await?;
         
         // Create primary wallets for citizen WITH seed phrases
         let mut wallet_manager = crate::wallets::WalletManager::new(id.clone());
@@ -105,6 +112,8 @@ impl IdentityManager {
             id.clone(),
             IdentityType::Human,
             public_key.clone(),
+            private_key.clone(),
+            "primary".to_string(),  // Default device name for new citizens
             ownership_proof,
             wallet_manager,
         )?;
@@ -116,7 +125,7 @@ impl IdentityManager {
         
         // Store private data
         let private_data = PrivateIdentityData::new(
-            private_key,
+            private_key_bytes,
             public_key.clone(),
             seed,
             recovery_options,
@@ -547,14 +556,23 @@ impl IdentityManager {
         }
         
         // Derive identity from recovery phrase
-        let (identity_id, private_key, public_key, seed) = recovery_manager.restore_from_phrase(&phrase_words).await?;
-        
+        let (identity_id, private_key_bytes, public_key, seed) = recovery_manager.restore_from_phrase(&phrase_words).await?;
+
+        // Wrap in PrivateKey struct
+        let private_key = lib_crypto::PrivateKey {
+            dilithium_sk: private_key_bytes.clone(),
+            kyber_sk: vec![],  // Not used in current implementation
+            master_seed: vec![],  // Derived separately
+        };
+
         // Create identity structure
         let mut identity = ZhtpIdentity::from_legacy_fields(
             identity_id.clone(),
             IdentityType::Human,
             public_key.clone(),
-            self.generate_ownership_proof(&private_key, &public_key).await?,
+            private_key.clone(),
+            "primary".to_string(),  // Default device name for imported identity
+            self.generate_ownership_proof(&private_key_bytes, &public_key).await?,
             crate::wallets::WalletManager::new(identity_id.clone()),
         )?;
 
@@ -565,7 +583,7 @@ impl IdentityManager {
         
         // Create private data
         let private_data = PrivateIdentityData::new(
-            private_key,
+            private_key_bytes,
             public_key,
             seed,
             vec![], // No additional recovery options for imported identities

--- a/src/identity/manager.rs
+++ b/src/identity/manager.rs
@@ -122,6 +122,7 @@ impl IdentityManager {
         identity.reputation = 500; // Citizens start with higher reputation
         identity.access_level = AccessLevel::FullCitizen;
         identity.citizenship_verified = true;
+        identity.dao_voting_power = 10; // Verified citizens get full voting power
         
         // Store private data
         let private_data = PrivateIdentityData::new(

--- a/src/integration/proof_generation.rs
+++ b/src/integration/proof_generation.rs
@@ -354,7 +354,7 @@ impl ProofGenerator {
         let mut proof_data = Vec::new();
         
         // Include identity public key
-        proof_data.extend_from_slice(&identity.public_key);
+        proof_data.extend_from_slice(&identity.public_key.as_bytes());
         
         // Include required identity attributes
         for attr in &request.required_attributes {
@@ -410,7 +410,7 @@ impl ProofGenerator {
     ) -> Result<(Vec<u8>, Vec<u8>, PrivacyLevel), Box<dyn std::error::Error>> {
         // Ownership proof using digital signature
         let mut proof_data = Vec::new();
-        proof_data.extend_from_slice(&identity.public_key);
+        proof_data.extend_from_slice(&identity.public_key.as_bytes());
         
         if let Some(challenge) = &request.challenge {
             proof_data.extend_from_slice(challenge);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ pub async fn create_user_identity_with_wallet(
         identity_id.clone(),
         IdentityType::Human,
         public_key.to_vec(),
+        keypair.private_key.clone(),
+        "primary".to_string(),  // Default device name for user identity
         lib_proofs::ZeroKnowledgeProof {
             proof_system: "UserIdentity".to_string(),
             proof_data: vec![0u8; 32],
@@ -209,6 +211,8 @@ pub async fn create_node_device_identity(
         node_identity_id.clone(),
         IdentityType::Device,
         public_key.to_vec(),
+        keypair.private_key.clone(),
+        node_name.clone(),  // Use node name as device name
         lib_proofs::ZeroKnowledgeProof {
             proof_system: "NodeDevice".to_string(),
             proof_data: vec![0u8; 32],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,11 +97,11 @@ pub async fn create_user_identity_with_wallet(
     let identity_id = Hash::from_bytes(&public_key);
     
     // Create a Human or Organization identity (can own nodes and have wallets)
-    let mut identity = ZhtpIdentity {
-        id: identity_id.clone(),
-        identity_type: IdentityType::Human,  // User identity, not device
-        public_key: public_key.to_vec(),
-        ownership_proof: lib_proofs::ZeroKnowledgeProof {
+    let mut identity = ZhtpIdentity::from_legacy_fields(
+        identity_id.clone(),
+        IdentityType::Human,
+        public_key.to_vec(),
+        lib_proofs::ZeroKnowledgeProof {
             proof_system: "UserIdentity".to_string(),
             proof_data: vec![0u8; 32],
             public_inputs: public_key.to_vec(),
@@ -109,32 +109,16 @@ pub async fn create_user_identity_with_wallet(
             plonky2_proof: None,
             proof: vec![],
         },
-        credentials: std::collections::HashMap::new(),
-        reputation: 100,
-        age: None,
-        access_level: AccessLevel::FullCitizen,
-        metadata: std::collections::HashMap::from([(
-            "user_name".to_string(),
-            user_name.clone(),
-        )]),
-        private_data_id: Some(identity_id.clone()),
-        wallet_manager: WalletManager::new(identity_id.clone()),
-        attestations: Vec::new(),
-        created_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs(),
-        last_active: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs(),
-        recovery_keys: vec![],
-        did_document_hash: None,
-        owner_identity_id: None,     // Users don't have owners
-        reward_wallet_id: None,       // Users don't need this (nodes do)
-        encrypted_master_seed: None,
-        next_wallet_index: 0,
-        password_hash: None,
-        master_seed_phrase: None,
-    };
+        WalletManager::new(identity_id.clone()),
+    )?;
+
+    // Set user-specific fields
+    identity.reputation = 100;
+    identity.access_level = AccessLevel::FullCitizen;
+    identity.metadata = std::collections::HashMap::from([(
+        "user_name".to_string(),
+        user_name.clone(),
+    )]);
     
     // Create PRIMARY wallet (main wallet for transactions and node rewards)
     let (primary_wallet_id, seed_phrase_struct) = identity.wallet_manager.create_wallet_with_seed_phrase(
@@ -221,11 +205,11 @@ pub async fn create_node_device_identity(
     let node_identity_id = Hash::from_bytes(&public_key);
     
     // Create a Device identity (for DHT/networking, owned by user)
-    let node_identity = ZhtpIdentity {
-        id: node_identity_id.clone(),
-        identity_type: IdentityType::Device,  // Device/node identity
-        public_key: public_key.to_vec(),
-        ownership_proof: lib_proofs::ZeroKnowledgeProof {
+    let mut node_identity = ZhtpIdentity::from_legacy_fields(
+        node_identity_id.clone(),
+        IdentityType::Device,
+        public_key.to_vec(),
+        lib_proofs::ZeroKnowledgeProof {
             proof_system: "NodeDevice".to_string(),
             proof_data: vec![0u8; 32],
             public_inputs: public_key.to_vec(),
@@ -233,32 +217,18 @@ pub async fn create_node_device_identity(
             plonky2_proof: None,
             proof: vec![],
         },
-        credentials: std::collections::HashMap::new(),
-        reputation: 100,
-        age: None,
-        access_level: AccessLevel::FullCitizen,
-        metadata: std::collections::HashMap::from([
-            ("node_name".to_string(), node_name.clone()),
-            ("owner_identity".to_string(), hex::encode(&owner_identity_id.0)),
-        ]),
-        private_data_id: Some(node_identity_id.clone()),
-        wallet_manager: WalletManager::new(node_identity_id.clone()),  // Empty wallet manager
-        attestations: Vec::new(),
-        created_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs(),
-        last_active: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs(),
-        recovery_keys: vec![],
-        did_document_hash: None,
-        owner_identity_id: Some(owner_identity_id.clone()),  // Owned by user
-        reward_wallet_id: Some(reward_wallet_id),     // Rewards go here
-        encrypted_master_seed: None,
-        next_wallet_index: 0,
-        password_hash: None,
-        master_seed_phrase: None,
-    };
+        WalletManager::new(node_identity_id.clone()),
+    )?;
+
+    // Set device-specific fields
+    node_identity.reputation = 100;
+    node_identity.access_level = AccessLevel::FullCitizen;
+    node_identity.metadata = std::collections::HashMap::from([
+        ("node_name".to_string(), node_name.clone()),
+        ("owner_identity".to_string(), hex::encode(&owner_identity_id.0)),
+    ]);
+    node_identity.owner_identity_id = Some(owner_identity_id.clone());
+    node_identity.reward_wallet_id = Some(reward_wallet_id);
     
     // Store the node identity
     let mut manager = IdentityManager::new();

--- a/src/privacy/zk_proofs.rs
+++ b/src/privacy/zk_proofs.rs
@@ -87,7 +87,7 @@ pub fn generate_ownership_proof(
 ) -> Result<OwnershipProof, String> {
     // Generate quantum-resistant signature for ownership proof
     let private_key = private_data.private_key();
-    let public_key = identity.public_key.clone();
+    let public_key = identity.public_key.as_bytes();
 
     // Create signature over challenge
     let signature = sign_challenge(private_key, challenge)?;
@@ -170,10 +170,10 @@ fn generate_citizenship_proof(identity: &ZhtpIdentity) -> Result<Vec<u8>, String
     Ok(proof_data)
 }
 
-fn generate_reputation_proof(identity: &ZhtpIdentity, threshold: u32) -> Result<Vec<u8>, String> {
+fn generate_reputation_proof(identity: &ZhtpIdentity, threshold: u64) -> Result<Vec<u8>, String> {
     // Prove reputation >= threshold
     let reputation = identity.reputation;
-    
+
     if reputation < threshold {
         return Err("Reputation requirement not met".to_string());
     }

--- a/src/reputation/scoring.rs
+++ b/src/reputation/scoring.rs
@@ -11,13 +11,13 @@ use std::collections::HashMap;
 /// Reputation score breakdown
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReputationBreakdown {
-    pub base_score: u32,           // Starting reputation
-    pub credential_bonus: u32,     // Points from verified credentials
-    pub citizen_bonus: u32,        // Bonus for citizenship
-    pub activity_bonus: u32,       // Points from network activity
-    pub verification_bonus: u32,   // Points from verifying others
-    pub penalty_deductions: u32,   // Deductions from violations
-    pub total_score: u32,          // Final reputation score (0-1000)
+    pub base_score: u64,           // Starting reputation
+    pub credential_bonus: u64,     // Points from verified credentials
+    pub citizen_bonus: u64,        // Bonus for citizenship
+    pub activity_bonus: u64,       // Points from network activity
+    pub verification_bonus: u64,   // Points from verifying others
+    pub penalty_deductions: u64,   // Deductions from violations
+    pub total_score: u64,          // Final reputation score (0-1000)
     pub reputation_tier: String,   // Reputation tier classification
 }
 
@@ -73,13 +73,13 @@ pub fn calculate_reputation_score(
     let reputation_tier = determine_reputation_tier(total_score);
     
     ReputationBreakdown {
-        base_score,
-        credential_bonus,
-        citizen_bonus,
-        activity_bonus,
-        verification_bonus,
-        penalty_deductions,
-        total_score,
+        base_score: base_score as u64,
+        credential_bonus: credential_bonus as u64,
+        citizen_bonus: citizen_bonus as u64,
+        activity_bonus: activity_bonus as u64,
+        verification_bonus: verification_bonus as u64,
+        penalty_deductions: penalty_deductions as u64,
+        total_score: total_score as u64,
         reputation_tier: reputation_tier.to_string(),
     }
 }
@@ -213,7 +213,7 @@ pub fn update_reputation_score(
 }
 
 /// Get reputation requirements for access levels
-pub fn get_reputation_requirements() -> HashMap<String, u32> {
+pub fn get_reputation_requirements() -> HashMap<String, u64> {
     let mut requirements = HashMap::new();
     
     requirements.insert("BasicAccess".to_string(), 0);

--- a/src/types/node_id.rs
+++ b/src/types/node_id.rs
@@ -338,6 +338,12 @@ impl std::fmt::Display for NodeId {
     }
 }
 
+impl Default for NodeId {
+    fn default() -> Self {
+        NodeId([0u8; 32])
+    }
+}
+
 // ============================================================================
 // TESTS - Written FIRST to define the contract (TDD)
 // ============================================================================

--- a/src/types/proof_params.rs
+++ b/src/types/proof_params.rs
@@ -15,7 +15,7 @@ pub struct IdentityProofParams {
     /// Privacy level (0 = public, 100 = maximum privacy)
     pub privacy_level: u8,
     /// Minimum reputation score required
-    pub min_reputation: Option<u32>,
+    pub min_reputation: Option<u64>,
     /// Proof type identifier
     pub proof_type: String,
     /// Require citizenship status
@@ -45,7 +45,7 @@ impl IdentityProofParams {
     }
     
     /// Set minimum reputation requirement
-    pub fn with_min_reputation(mut self, min_reputation: u32) -> Self {
+    pub fn with_min_reputation(mut self, min_reputation: u64) -> Self {
         self.min_reputation = Some(min_reputation);
         self
     }

--- a/src/verification/identity_verification.rs
+++ b/src/verification/identity_verification.rs
@@ -609,6 +609,7 @@ mod tests {
             "test_device".to_string(),
             Some(30),
             Some("US".to_string()),
+            false,  // Not a verified citizen in test
             ownership_proof,
         ).expect("Failed to create test identity")
     }

--- a/src/verification/identity_verification.rs
+++ b/src/verification/identity_verification.rs
@@ -587,7 +587,12 @@ mod tests {
     use lib_proofs::ZeroKnowledgeProof;
 
     fn create_test_identity() -> ZhtpIdentity {
-        let public_key = vec![42u8; 32];
+        let public_key = lib_crypto::PublicKey::new(vec![42u8; 64]);
+        let private_key = lib_crypto::PrivateKey {
+            dilithium_sk: vec![1u8; 32],
+            kyber_sk: vec![],
+            master_seed: vec![],
+        };
         let ownership_proof = ZeroKnowledgeProof {
             proof_system: "Test".to_string(),
             proof_data: vec![1, 2, 3, 4],
@@ -596,10 +601,14 @@ mod tests {
             plonky2_proof: None,
             proof: vec![],
         };
-        
+
         ZhtpIdentity::new(
             IdentityType::Human,
             public_key,
+            private_key,
+            "test_device".to_string(),
+            Some(30),
+            Some("US".to_string()),
             ownership_proof,
         ).expect("Failed to create test identity")
     }

--- a/src/verification/identity_verification.rs
+++ b/src/verification/identity_verification.rs
@@ -587,9 +587,15 @@ mod tests {
     use lib_proofs::ZeroKnowledgeProof;
 
     fn create_test_identity() -> ZhtpIdentity {
-        let public_key = lib_crypto::PublicKey::new(vec![42u8; 64]);
+        // Use realistic Dilithium2 key sizes for testing
+        // Dilithium2: PK = 1312 bytes, SK = 2528 bytes
+        let public_key = lib_crypto::PublicKey {
+            dilithium_pk: vec![42u8; 1312],  // Real Dilithium2 public key size
+            kyber_pk: vec![],
+            key_id: [42u8; 32],
+        };
         let private_key = lib_crypto::PrivateKey {
-            dilithium_sk: vec![1u8; 32],
+            dilithium_sk: vec![1u8; 2528],   // Real Dilithium2 secret key size
             kyber_sk: vec![],
             master_seed: vec![],
         };

--- a/src/verification/identity_verification.rs
+++ b/src/verification/identity_verification.rs
@@ -319,7 +319,7 @@ impl IdentityVerifier {
         let signature_valid = true; // Would verify actual signature here
 
         // Verify public key format and quantum resistance
-        let key_format_valid = identity.public_key.len() >= 32; // Minimum key size
+        let key_format_valid = identity.public_key.as_bytes().len() >= 32; // Minimum key size
         let quantum_resistant = true; // Would check if using post-quantum algorithms
 
         Ok(CryptoVerificationResult {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -21,7 +21,8 @@ async fn test_complete_citizen_onboarding_flow() {
     
     // Create a new citizen identity with complete onboarding
     let citizenship_result = manager.create_citizen_identity(
-        vec!["test recovery phrase".to_string()],
+        "Test Citizen".to_string(),
+        vec!["test@example.com".to_string()],
         &mut economic_model,
     ).await.expect("Failed to create citizen identity");
     
@@ -244,24 +245,24 @@ async fn test_wallet_integration() {
     let owner_id = Hash([42u8; 32]);
     let mut wallet_manager = WalletManager::new(owner_id.clone());
     
-    // Create different types of wallets
-    let primary_wallet = wallet_manager.create_wallet(
+    // Create different types of wallets with seed phrases
+    let (primary_wallet, _seed1) = wallet_manager.create_wallet_with_seed_phrase(
         WalletType::Primary,
         "Primary Wallet".to_string(),
         Some("primary".to_string()),
-    ).expect("Failed to create primary wallet");
-    
-    let ubi_wallet = wallet_manager.create_wallet(
+    ).await.expect("Failed to create primary wallet");
+
+    let (ubi_wallet, _seed2) = wallet_manager.create_wallet_with_seed_phrase(
         WalletType::UBI,
         "UBI Wallet".to_string(),
         Some("ubi".to_string()),
-    ).expect("Failed to create UBI wallet");
-    
-    let savings_wallet = wallet_manager.create_wallet(
+    ).await.expect("Failed to create UBI wallet");
+
+    let (savings_wallet, _seed3) = wallet_manager.create_wallet_with_seed_phrase(
         WalletType::Savings,
         "Savings Wallet".to_string(),
         Some("savings".to_string()),
-    ).expect("Failed to create savings wallet");
+    ).await.expect("Failed to create savings wallet");
     
     // Test wallet retrieval
     assert!(wallet_manager.get_wallet(&primary_wallet).is_some());
@@ -340,12 +341,12 @@ async fn test_citizenship_system_integration() {
     let mut citizen_results = Vec::new();
     
     for i in 0..3 {
-        let result = manager.onboard_new_citizen(
+        let result = manager.create_citizen_identity(
             format!("Citizen {}", i + 1),
-            vec![format!("recovery phrase for citizen {}", i + 1)],
+            vec![format!("recovery@citizen{}.com", i + 1)],
             &mut economic_model,
-        ).await.expect("Failed to onboard citizen");
-        
+        ).await.expect("Failed to create citizen");
+
         citizen_results.push(result);
     }
     
@@ -374,8 +375,13 @@ async fn test_citizenship_system_integration() {
 
 async fn create_test_identity() -> identity::ZhtpIdentity {
     use lib_proofs::ZeroKnowledgeProof;
-    
-    let public_key = vec![42u8; 32];
+
+    let public_key = lib_crypto::PublicKey::new(vec![42u8; 64]);
+    let private_key = lib_crypto::PrivateKey {
+        dilithium_sk: vec![1u8; 32],
+        kyber_sk: vec![],
+        master_seed: vec![],
+    };
     let ownership_proof = ZeroKnowledgeProof {
         proof_system: "Test".to_string(),
         proof_data: vec![1, 2, 3, 4],
@@ -384,10 +390,14 @@ async fn create_test_identity() -> identity::ZhtpIdentity {
         plonky2_proof: None,
         proof: vec![],
     };
-    
+
     identity::ZhtpIdentity::new(
         IdentityType::Human,
         public_key,
+        private_key,
+        "test_device".to_string(),
+        Some(30),
+        Some("US".to_string()),
         ownership_proof,
     ).expect("Failed to create test identity")
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -398,6 +398,7 @@ async fn create_test_identity() -> identity::ZhtpIdentity {
         "test_device".to_string(),
         Some(30),
         Some("US".to_string()),
+        false,  // Not a verified citizen in test
         ownership_proof,
     ).expect("Failed to create test identity")
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -376,9 +376,15 @@ async fn test_citizenship_system_integration() {
 async fn create_test_identity() -> identity::ZhtpIdentity {
     use lib_proofs::ZeroKnowledgeProof;
 
-    let public_key = lib_crypto::PublicKey::new(vec![42u8; 64]);
+    // Use realistic Dilithium2 key sizes for testing
+    // Dilithium2: PK = 1312 bytes, SK = 2528 bytes
+    let public_key = lib_crypto::PublicKey {
+        dilithium_pk: vec![42u8; 1312],  // Real Dilithium2 public key size
+        kyber_pk: vec![],
+        key_id: [42u8; 32],
+    };
     let private_key = lib_crypto::PrivateKey {
-        dilithium_sk: vec![1u8; 32],
+        dilithium_sk: vec![1u8; 2528],   // Real Dilithium2 secret key size
         kyber_sk: vec![],
         master_seed: vec![],
     };

--- a/tests/zhtp_identity_fields.rs
+++ b/tests/zhtp_identity_fields.rs
@@ -251,39 +251,82 @@ fn test_deserialization_requires_rederive() {
     // Serialize
     let json = serde_json::to_string(&identity).expect("Serialization should succeed");
 
-    // Deserialize - secrets will be zero
-    let mut deserialized: ZhtpIdentity = serde_json::from_str(&json).expect("Deserialization should succeed");
+    // UNSAFE PATH: Direct deserialization (demonstrates the security risk)
+    let mut deserialized_unsafe: ZhtpIdentity = serde_json::from_str(&json)
+        .expect("Deserialization should succeed");
 
     // SECURITY: Secrets should be zero after deserialization
-    assert!(!deserialized.is_secrets_derived(), "Secrets should be zero after deserialization");
-    assert!(deserialized.validate_secrets_derived().is_err(), "Validation should fail for zero secrets");
+    assert!(!deserialized_unsafe.is_secrets_derived(),
+        "Secrets should be zero after direct deserialization");
+    assert!(deserialized_unsafe.validate_secrets_derived().is_err(),
+        "Validation should fail for zero secrets");
 
-    // Re-derive secrets
+    // Manual re-derivation (required if using direct deserialization)
     let private_key = PrivateKey {
         dilithium_sk: vec![1u8; 2528],
         kyber_sk: vec![],
         master_seed: vec![],
     };
-    deserialized.rederive_secrets(&private_key).expect("Rederivation should succeed");
+    deserialized_unsafe.rederive_secrets(&private_key)
+        .expect("Rederivation should succeed");
 
     // Now secrets should be valid
-    assert!(deserialized.is_secrets_derived(), "Secrets should be derived after rederive_secrets()");
-    assert!(deserialized.validate_secrets_derived().is_ok(), "Validation should pass after rederivation");
+    assert!(deserialized_unsafe.is_secrets_derived(),
+        "Secrets should be derived after rederive_secrets()");
+    assert!(deserialized_unsafe.validate_secrets_derived().is_ok(),
+        "Validation should pass after rederivation");
+
+    // SAFE PATH: Using from_serialized helper (enforces re-derivation)
+    let deserialized_safe = ZhtpIdentity::from_serialized(&json, &private_key)
+        .expect("Safe deserialization should succeed");
+
+    // Secrets should already be derived
+    assert!(deserialized_safe.is_secrets_derived(),
+        "Secrets should be derived immediately with from_serialized()");
+    assert!(deserialized_safe.validate_secrets_derived().is_ok(),
+        "Validation should pass for from_serialized()");
+
+    // Verify both paths produce identical results
+    assert_eq!(deserialized_unsafe.did, deserialized_safe.did,
+        "Both paths should produce same DID");
+    assert_eq!(deserialized_unsafe.zk_identity_secret, deserialized_safe.zk_identity_secret,
+        "Both paths should produce same ZK secret");
+    assert_eq!(deserialized_unsafe.zk_credential_hash, deserialized_safe.zk_credential_hash,
+        "Both paths should produce same credential hash");
+    assert_eq!(deserialized_unsafe.wallet_master_seed, deserialized_safe.wallet_master_seed,
+        "Both paths should produce same wallet seed");
 }
 
-// GOLDEN VECTOR TEST: Validate deterministic derivation
+// GOLDEN VECTOR TEST: Validate deterministic derivation with expected outputs
 #[test]
 fn test_deterministic_derivation_golden_vector() {
-    // Using fixed key material to validate deterministic derivation
-    let public_key = PublicKey {
-        dilithium_pk: vec![42u8; 1312],
+    // Golden vector: Fixed key material with precomputed expected outputs
+    // This validates that derivation algorithms produce expected results
+
+    // Test vector 1: All zeros (simple case for validation)
+    let public_key_zeros = PublicKey {
+        dilithium_pk: vec![0u8; 1312],  // Real Dilithium2 PK size
         kyber_pk: vec![],
-        key_id: [42u8; 32],
+        key_id: [0u8; 32],
     };
-    let private_key = PrivateKey {
-        dilithium_sk: vec![1u8; 2528],
+    let private_key_zeros = PrivateKey {
+        dilithium_sk: vec![0u8; 2528],  // Real Dilithium2 SK size
         kyber_sk: vec![],
         master_seed: vec![],
+    };
+
+    // Expected outputs for all-zero keys (precomputed with blake3)
+    // DID = "did:zhtp:" + hex(blake3(vec![0u8; 1312]))
+    let expected_did_zeros = {
+        let hash = lib_crypto::hash_blake3(&vec![0u8; 1312]);
+        format!("did:zhtp:{}", hex::encode(hash))
+    };
+
+    // Expected ZK secret = blake3("ZHTP_ZK_SECRET_V1:" + vec![0u8; 2528])
+    let expected_zk_secret_zeros = {
+        let mut data = b"ZHTP_ZK_SECRET_V1:".to_vec();
+        data.extend_from_slice(&vec![0u8; 2528]);
+        lib_crypto::hash_blake3(&data)
     };
 
     let ownership_proof = ZeroKnowledgeProof {
@@ -295,40 +338,85 @@ fn test_deterministic_derivation_golden_vector() {
         proof: vec![],
     };
 
-    // Create identity twice with same keys
-    let identity1 = ZhtpIdentity::new(
+    let identity_zeros = ZhtpIdentity::new(
         IdentityType::Human,
-        public_key.clone(),
-        private_key.clone(),
+        public_key_zeros.clone(),
+        private_key_zeros.clone(),
         "laptop".to_string(),
         Some(30u64),
         Some("US".to_string()),
         true,
         ownership_proof.clone(),
-    ).expect("Failed to create identity 1");
+    ).expect("Failed to create identity with zero keys");
 
-    let identity2 = ZhtpIdentity::new(
+    // Validate DID derivation
+    assert_eq!(identity_zeros.did, expected_did_zeros,
+        "DID should match blake3(dilithium_pk) for zero keys");
+    assert_eq!(identity_zeros.did.len(), 73, "DID should be 73 chars (did:zhtp: + 64 hex)");
+
+    // Validate ZK secret derivation
+    assert_eq!(identity_zeros.zk_identity_secret, expected_zk_secret_zeros,
+        "ZK secret should match expected hash for zero keys");
+
+    // Test vector 2: Non-zero pattern (validates different inputs produce different outputs)
+    let public_key_pattern = PublicKey {
+        dilithium_pk: vec![0xAB; 1312],  // Pattern: 0xAB repeated
+        kyber_pk: vec![],
+        key_id: [0xCD; 32],
+    };
+    let private_key_pattern = PrivateKey {
+        dilithium_sk: vec![0xEF; 2528],  // Pattern: 0xEF repeated
+        kyber_sk: vec![],
+        master_seed: vec![],
+    };
+
+    let identity_pattern = ZhtpIdentity::new(
         IdentityType::Human,
-        public_key.clone(),
-        private_key.clone(),
+        public_key_pattern.clone(),
+        private_key_pattern.clone(),
         "laptop".to_string(),
         Some(30u64),
         Some("US".to_string()),
         true,
         ownership_proof.clone(),
-    ).expect("Failed to create identity 2");
+    ).expect("Failed to create identity with pattern keys");
 
-    // All derived fields should match (deterministic)
-    assert_eq!(identity1.did, identity2.did, "DID should be deterministic");
-    assert_eq!(identity1.zk_identity_secret, identity2.zk_identity_secret, "ZK secret should be deterministic");
-    assert_eq!(identity1.zk_credential_hash, identity2.zk_credential_hash, "Credential hash should be deterministic");
-    assert_eq!(identity1.wallet_master_seed, identity2.wallet_master_seed, "Wallet seed should be deterministic");
-    assert_eq!(identity1.dao_member_id, identity2.dao_member_id, "DAO member ID should be deterministic");
+    // Different inputs should produce different outputs
+    assert_ne!(identity_pattern.did, identity_zeros.did,
+        "Different public keys should produce different DIDs");
+    assert_ne!(identity_pattern.zk_identity_secret, identity_zeros.zk_identity_secret,
+        "Different private keys should produce different ZK secrets");
 
-    // Validate expected DID format from blake3(dilithium_pk)
-    let expected_did_hash = lib_crypto::hash_blake3(&public_key.dilithium_pk);
-    let expected_did = format!("did:zhtp:{}", hex::encode(expected_did_hash));
-    assert_eq!(identity1.did, expected_did, "DID should match blake3(dilithium_pk)");
+    // Test vector 3: Determinism check - same inputs produce same outputs
+    let identity_pattern_2 = ZhtpIdentity::new(
+        IdentityType::Human,
+        public_key_pattern.clone(),
+        private_key_pattern.clone(),
+        "laptop".to_string(),
+        Some(30u64),
+        Some("US".to_string()),
+        true,
+        ownership_proof.clone(),
+    ).expect("Failed to create second identity with pattern keys");
+
+    assert_eq!(identity_pattern.did, identity_pattern_2.did,
+        "Same inputs should produce same DID (deterministic)");
+    assert_eq!(identity_pattern.zk_identity_secret, identity_pattern_2.zk_identity_secret,
+        "Same inputs should produce same ZK secret (deterministic)");
+    assert_eq!(identity_pattern.zk_credential_hash, identity_pattern_2.zk_credential_hash,
+        "Same inputs should produce same credential hash (deterministic)");
+    assert_eq!(identity_pattern.wallet_master_seed, identity_pattern_2.wallet_master_seed,
+        "Same inputs should produce same wallet seed (deterministic)");
+    assert_eq!(identity_pattern.dao_member_id, identity_pattern_2.dao_member_id,
+        "Same inputs should produce same DAO member ID (deterministic)");
+
+    // Validate all secrets are non-zero for non-zero input
+    assert_ne!(identity_pattern.zk_identity_secret, [0u8; 32],
+        "ZK secret should be non-zero for non-zero input");
+    assert_ne!(identity_pattern.zk_credential_hash, [0u8; 32],
+        "Credential hash should be non-zero for non-zero input");
+    assert_ne!(identity_pattern.wallet_master_seed, [0u8; 64],
+        "Wallet seed should be non-zero for non-zero input");
 }
 
 // TEST: Voting power follows citizenship rules

--- a/tests/zhtp_identity_fields.rs
+++ b/tests/zhtp_identity_fields.rs
@@ -189,10 +189,16 @@ fn test_citizenship_fields() {
 // Helper function to create test identity using proper new() constructor
 // This ensures all cryptographic fields are derived correctly per spec
 fn create_test_identity() -> ZhtpIdentity {
-    // Use a real-ish keypair for testing (deterministic for repeatability)
-    let public_key = PublicKey::new(vec![42u8; 64]);
+    // Use realistic Dilithium2 key sizes for testing
+    // Dilithium2: PK = 1312 bytes, SK = 2528 bytes
+    // Using deterministic values for repeatability in tests
+    let public_key = PublicKey {
+        dilithium_pk: vec![42u8; 1312],  // Real Dilithium2 public key size
+        kyber_pk: vec![],
+        key_id: [42u8; 32],
+    };
     let private_key = PrivateKey {
-        dilithium_sk: vec![1u8; 32],
+        dilithium_sk: vec![1u8; 2528],   // Real Dilithium2 secret key size
         kyber_sk: vec![],
         master_seed: vec![],
     };
@@ -222,4 +228,167 @@ fn create_test_identity() -> ZhtpIdentity {
     identity.reputation = 1000u64;
 
     identity
+}
+
+// SECURITY TEST: Validate secrets are properly derived
+#[test]
+fn test_secrets_validation() {
+    let identity = create_test_identity();
+
+    // Secrets should be properly derived (non-zero)
+    assert!(identity.is_secrets_derived(), "Secrets should be derived after new()");
+    assert!(identity.validate_secrets_derived().is_ok(), "Validation should pass for derived secrets");
+}
+
+// SECURITY TEST: Deserialization produces zero secrets that must be re-derived
+#[test]
+fn test_deserialization_requires_rederive() {
+    use serde_json;
+
+    // Create identity with proper derivation
+    let identity = create_test_identity();
+
+    // Serialize
+    let json = serde_json::to_string(&identity).expect("Serialization should succeed");
+
+    // Deserialize - secrets will be zero
+    let mut deserialized: ZhtpIdentity = serde_json::from_str(&json).expect("Deserialization should succeed");
+
+    // SECURITY: Secrets should be zero after deserialization
+    assert!(!deserialized.is_secrets_derived(), "Secrets should be zero after deserialization");
+    assert!(deserialized.validate_secrets_derived().is_err(), "Validation should fail for zero secrets");
+
+    // Re-derive secrets
+    let private_key = PrivateKey {
+        dilithium_sk: vec![1u8; 2528],
+        kyber_sk: vec![],
+        master_seed: vec![],
+    };
+    deserialized.rederive_secrets(&private_key).expect("Rederivation should succeed");
+
+    // Now secrets should be valid
+    assert!(deserialized.is_secrets_derived(), "Secrets should be derived after rederive_secrets()");
+    assert!(deserialized.validate_secrets_derived().is_ok(), "Validation should pass after rederivation");
+}
+
+// GOLDEN VECTOR TEST: Validate deterministic derivation
+#[test]
+fn test_deterministic_derivation_golden_vector() {
+    // Using fixed key material to validate deterministic derivation
+    let public_key = PublicKey {
+        dilithium_pk: vec![42u8; 1312],
+        kyber_pk: vec![],
+        key_id: [42u8; 32],
+    };
+    let private_key = PrivateKey {
+        dilithium_sk: vec![1u8; 2528],
+        kyber_sk: vec![],
+        master_seed: vec![],
+    };
+
+    let ownership_proof = ZeroKnowledgeProof {
+        proof_system: "test".to_string(),
+        proof_data: vec![],
+        public_inputs: vec![],
+        verification_key: vec![],
+        plonky2_proof: None,
+        proof: vec![],
+    };
+
+    // Create identity twice with same keys
+    let identity1 = ZhtpIdentity::new(
+        IdentityType::Human,
+        public_key.clone(),
+        private_key.clone(),
+        "laptop".to_string(),
+        Some(30u64),
+        Some("US".to_string()),
+        true,
+        ownership_proof.clone(),
+    ).expect("Failed to create identity 1");
+
+    let identity2 = ZhtpIdentity::new(
+        IdentityType::Human,
+        public_key.clone(),
+        private_key.clone(),
+        "laptop".to_string(),
+        Some(30u64),
+        Some("US".to_string()),
+        true,
+        ownership_proof.clone(),
+    ).expect("Failed to create identity 2");
+
+    // All derived fields should match (deterministic)
+    assert_eq!(identity1.did, identity2.did, "DID should be deterministic");
+    assert_eq!(identity1.zk_identity_secret, identity2.zk_identity_secret, "ZK secret should be deterministic");
+    assert_eq!(identity1.zk_credential_hash, identity2.zk_credential_hash, "Credential hash should be deterministic");
+    assert_eq!(identity1.wallet_master_seed, identity2.wallet_master_seed, "Wallet seed should be deterministic");
+    assert_eq!(identity1.dao_member_id, identity2.dao_member_id, "DAO member ID should be deterministic");
+
+    // Validate expected DID format from blake3(dilithium_pk)
+    let expected_did_hash = lib_crypto::hash_blake3(&public_key.dilithium_pk);
+    let expected_did = format!("did:zhtp:{}", hex::encode(expected_did_hash));
+    assert_eq!(identity1.did, expected_did, "DID should match blake3(dilithium_pk)");
+}
+
+// TEST: Voting power follows citizenship rules
+#[test]
+fn test_dao_voting_power_rules() {
+    let public_key = PublicKey {
+        dilithium_pk: vec![42u8; 1312],
+        kyber_pk: vec![],
+        key_id: [42u8; 32],
+    };
+    let private_key = PrivateKey {
+        dilithium_sk: vec![1u8; 2528],
+        kyber_sk: vec![],
+        master_seed: vec![],
+    };
+    let ownership_proof = ZeroKnowledgeProof {
+        proof_system: "test".to_string(),
+        proof_data: vec![],
+        public_inputs: vec![],
+        verification_key: vec![],
+        plonky2_proof: None,
+        proof: vec![],
+    };
+
+    // Verified citizen: voting power = 10
+    let verified_citizen = ZhtpIdentity::new(
+        IdentityType::Human,
+        public_key.clone(),
+        private_key.clone(),
+        "device1".to_string(),
+        Some(30),
+        Some("US".to_string()),
+        true,  // verified
+        ownership_proof.clone(),
+    ).expect("Failed to create verified citizen");
+    assert_eq!(verified_citizen.dao_voting_power, 10, "Verified citizen should have voting power 10");
+
+    // Unverified human: voting power = 1
+    let unverified_human = ZhtpIdentity::new(
+        IdentityType::Human,
+        public_key.clone(),
+        private_key.clone(),
+        "device2".to_string(),
+        Some(30),
+        Some("US".to_string()),
+        false,  // not verified
+        ownership_proof.clone(),
+    ).expect("Failed to create unverified human");
+    assert_eq!(unverified_human.dao_voting_power, 1, "Unverified human should have voting power 1");
+
+    // Device type: voting power = 0
+    let device = ZhtpIdentity::new(
+        IdentityType::Device,
+        public_key.clone(),
+        private_key.clone(),
+        "device3".to_string(),
+        None,
+        None,
+        false,
+        ownership_proof.clone(),
+    ).expect("Failed to create device");
+    assert_eq!(device.dao_voting_power, 0, "Device should have voting power 0");
 }

--- a/tests/zhtp_identity_fields.rs
+++ b/tests/zhtp_identity_fields.rs
@@ -1,0 +1,234 @@
+// P1-5: Add new identity fields to ZhtpIdentity struct
+// Acceptance Criteria Tests
+
+use lib_identity::identity::ZhtpIdentity;
+use lib_identity::types::{IdentityType, NodeId, IdentityId, AccessLevel};
+use lib_identity::wallets::WalletManager;
+use lib_crypto::{PublicKey, PrivateKey};
+use lib_proofs::ZeroKnowledgeProof;
+use std::collections::HashMap;
+
+// AC1: New fields added to ZhtpIdentity
+// Given: ZhtpIdentity struct in lib_identity.rs
+// When: new fields are added
+// Then: struct includes did, node_id, device_node_ids, primary_device,
+//       zk_identity_secret, zk_credential_hash, wallet_master_seed,
+//       dao_member_id, dao_voting_power, citizenship_verified, jurisdiction
+#[test]
+fn test_zhtp_identity_has_required_fields() {
+    let node_id = NodeId::from_did_device("did:zhtp:test123", "laptop")
+        .expect("Valid NodeId");
+
+    let mut device_node_ids = HashMap::new();
+    device_node_ids.insert("laptop".to_string(), node_id);
+
+    let identity = create_test_identity();
+
+    // Verify all new fields are accessible
+    assert_eq!(identity.did, "did:zhtp:test123");
+    assert_eq!(identity.primary_device, "laptop");
+    assert_eq!(identity.dao_voting_power, 100);
+    assert_eq!(identity.citizenship_verified, true);
+    assert_eq!(identity.jurisdiction, Some("US".to_string()));
+    assert_eq!(identity.device_node_ids.len(), 1);
+    assert_eq!(identity.zk_identity_secret.len(), 32);
+    assert_eq!(identity.zk_credential_hash.len(), 32);
+    assert_eq!(identity.wallet_master_seed.len(), 64);
+}
+
+// AC2: Correct types from lib-crypto
+// Given: lib-crypto PublicKey/PrivateKey types
+// When: fields are added
+// Then: public_key is lib_crypto::PublicKey, private_key is Option<lib_crypto::PrivateKey>
+#[test]
+fn test_zhtp_identity_uses_lib_crypto_types() {
+    let identity = create_test_identity();
+
+    // Verify types at compile time - this test passes if it compiles
+    let _pk: &PublicKey = &identity.public_key;
+    let _sk: &Option<PrivateKey> = &identity.private_key;
+}
+
+// AC3: private_key uses serde(skip)
+// Given: new fields with sensitive data
+// When: Serialize trait is implemented
+// Then: private_key uses serde(skip) to exclude private key
+#[test]
+fn test_private_key_not_serialized() {
+    use serde_json;
+
+    let mut identity = create_test_identity();
+    // PrivateKey doesn't have Default, skip setting it for test
+
+    let json = serde_json::to_string(&identity)
+        .expect("Serialization should succeed");
+
+    // Verify private_key is not in JSON
+    assert!(!json.contains("private_key"),
+            "private_key should be skipped in serialization");
+
+    // Verify did IS in JSON (sanity check)
+    assert!(json.contains("did:zhtp:test123"),
+            "did should be present in serialization");
+}
+
+// AC4: Type corrections for existing fields
+// Given: existing type inconsistencies
+// When: fields are corrected
+// Then: age: Option<u8> → Option<u64>, reputation: u32 → u64
+#[test]
+fn test_field_type_corrections() {
+    let identity = create_test_identity();
+
+    // Verify age is Option<u64>
+    let _age: Option<u64> = identity.age;
+    assert_eq!(identity.age, Some(30u64));
+
+    // Verify reputation is u64
+    let _reputation: u64 = identity.reputation;
+    assert_eq!(identity.reputation, 1000u64);
+}
+
+// AC5: HashMap for device_node_ids
+// Given: multi-device support requirement
+// When: device_node_ids field is added
+// Then: it maps device names (String) to NodeId
+#[test]
+fn test_device_node_ids_mapping() {
+    let laptop_id = NodeId::from_did_device("did:zhtp:test123", "laptop")
+        .expect("Valid NodeId");
+    let phone_id = NodeId::from_did_device("did:zhtp:test123", "phone")
+        .expect("Valid NodeId");
+
+    let mut device_node_ids = HashMap::new();
+    device_node_ids.insert("laptop".to_string(), laptop_id);
+    device_node_ids.insert("phone".to_string(), phone_id);
+
+    let mut identity = create_test_identity();
+    identity.device_node_ids = device_node_ids;
+    identity.primary_device = "laptop".to_string();
+
+    // Verify mapping
+    assert_eq!(identity.device_node_ids.len(), 2);
+    assert!(identity.device_node_ids.contains_key("laptop"));
+    assert!(identity.device_node_ids.contains_key("phone"));
+    assert_eq!(identity.primary_device, "laptop");
+}
+
+// AC6: Fixed-size arrays for secrets
+// Given: cryptographic secret fields
+// When: fields are added
+// Then: zk_identity_secret is [u8; 32], zk_credential_hash is [u8; 32],
+//       wallet_master_seed is [u8; 64]
+#[test]
+fn test_secret_fields_fixed_sizes() {
+    let mut identity = create_test_identity();
+
+    // Verify compile-time sizes
+    let _zk_secret: [u8; 32] = identity.zk_identity_secret;
+    let _zk_hash: [u8; 32] = identity.zk_credential_hash;
+    let _wallet_seed: [u8; 64] = identity.wallet_master_seed;
+
+    // Set some test values
+    identity.zk_identity_secret = [1u8; 32];
+    identity.zk_credential_hash = [2u8; 32];
+    identity.wallet_master_seed = [3u8; 64];
+
+    assert_eq!(identity.zk_identity_secret.len(), 32);
+    assert_eq!(identity.zk_credential_hash.len(), 32);
+    assert_eq!(identity.wallet_master_seed.len(), 64);
+}
+
+// AC7: DAO fields present and correct types
+// Given: DAO integration requirements
+// When: DAO fields are added
+// Then: dao_member_id is String, dao_voting_power is u64
+#[test]
+fn test_dao_fields() {
+    let mut identity = create_test_identity();
+    identity.dao_member_id = "dao_member_xyz".to_string();
+    identity.dao_voting_power = 5000u64;
+
+    // Verify types
+    let _member_id: String = identity.dao_member_id.clone();
+    let _voting_power: u64 = identity.dao_voting_power;
+
+    assert_eq!(identity.dao_member_id, "dao_member_xyz");
+    assert_eq!(identity.dao_voting_power, 5000);
+}
+
+// AC8: Citizenship fields present
+// Given: jurisdiction verification requirements
+// When: citizenship fields are added
+// Then: citizenship_verified is bool, jurisdiction is Option<String>
+#[test]
+fn test_citizenship_fields() {
+    let mut identity = create_test_identity();
+
+    // Test verified citizen with jurisdiction
+    identity.citizenship_verified = true;
+    identity.jurisdiction = Some("US".to_string());
+
+    assert_eq!(identity.citizenship_verified, true);
+    assert_eq!(identity.jurisdiction, Some("US".to_string()));
+
+    // Test unverified citizen
+    identity.citizenship_verified = false;
+    identity.jurisdiction = None;
+
+    assert_eq!(identity.citizenship_verified, false);
+    assert_eq!(identity.jurisdiction, None);
+}
+
+// Helper function to create test identity
+fn create_test_identity() -> ZhtpIdentity {
+    let node_id = NodeId::from_did_device("did:zhtp:test123", "laptop")
+        .expect("Valid NodeId");
+
+    let mut device_node_ids = HashMap::new();
+    device_node_ids.insert("laptop".to_string(), node_id);
+
+    ZhtpIdentity {
+        id: lib_crypto::Hash::from_bytes(&[0u8; 32]),
+        identity_type: IdentityType::Human,
+        did: "did:zhtp:test123".to_string(),
+        public_key: PublicKey::new(vec![1u8; 64]),
+        private_key: None,
+        node_id,
+        device_node_ids,
+        primary_device: "laptop".to_string(),
+        zk_identity_secret: [0u8; 32],
+        zk_credential_hash: [0u8; 32],
+        wallet_master_seed: [0u8; 64],
+        dao_member_id: "dao_member_123".to_string(),
+        dao_voting_power: 100,
+        citizenship_verified: true,
+        jurisdiction: Some("US".to_string()),
+        age: Some(30u64),
+        reputation: 1000u64,
+        created_at: 0,
+        last_active: 0,
+        recovery_keys: vec![],
+        did_document_hash: None,
+        owner_identity_id: None,
+        reward_wallet_id: None,
+        encrypted_master_seed: None,
+        next_wallet_index: 0,
+        password_hash: None,
+        master_seed_phrase: None,
+        attestations: vec![],
+        wallet_manager: WalletManager::new(lib_crypto::Hash::from_bytes(&[0u8; 32])),
+        ownership_proof: ZeroKnowledgeProof {
+            proof_system: "test".to_string(),
+            proof_data: vec![],
+            public_inputs: vec![],
+            verification_key: vec![],
+            plonky2_proof: None,
+            proof: vec![],
+        },
+        access_level: AccessLevel::default(),
+        metadata: std::collections::HashMap::new(),
+        credentials: std::collections::HashMap::new(),
+        private_data_id: None,
+    }
+}

--- a/tests/zhtp_identity_fields.rs
+++ b/tests/zhtp_identity_fields.rs
@@ -305,10 +305,8 @@ fn test_deterministic_derivation_golden_vector() {
     };
 
     // Expected outputs for all-zero keys (computed per spec, not via derive functions)
-    let expected_did_zeros = {
-        let hash = blake3::hash(&public_key_zeros.dilithium_pk);
-        format!("did:zhtp:{}", hash.to_hex())
-    };
+    // Per Issue #9: DID uses key_id directly, not hash of dilithium_pk
+    let expected_did_zeros = format!("did:zhtp:{}", hex::encode(public_key_zeros.key_id));
 
     let expected_zk_secret_zeros = {
         let mut hasher = blake3::Hasher::new();
@@ -365,7 +363,7 @@ fn test_deterministic_derivation_golden_vector() {
 
     // Validate DID derivation
     assert_eq!(identity_zeros.did, expected_did_zeros,
-        "DID should match blake3(dilithium_pk) for zero keys");
+        "DID should match hex(key_id) for zero keys");
     assert_eq!(identity_zeros.did.len(), 73, "DID should be 73 chars (did:zhtp: + 64 hex)");
 
     // Validate ZK secret derivation

--- a/tests/zhtp_identity_fields.rs
+++ b/tests/zhtp_identity_fields.rs
@@ -6,6 +6,7 @@ use lib_identity::types::{IdentityType, NodeId, IdentityId, AccessLevel};
 use lib_identity::wallets::WalletManager;
 use lib_crypto::{PublicKey, PrivateKey};
 use lib_proofs::ZeroKnowledgeProof;
+use blake3;
 use std::collections::HashMap;
 
 // AC1: New fields added to ZhtpIdentity
@@ -240,7 +241,7 @@ fn test_secrets_validation() {
     assert!(identity.validate_secrets_derived().is_ok(), "Validation should pass for derived secrets");
 }
 
-// SECURITY TEST: Deserialization produces zero secrets that must be re-derived
+// SECURITY TEST: Direct deserialization is blocked, must use from_serialized
 #[test]
 fn test_deserialization_requires_rederive() {
     use serde_json;
@@ -251,50 +252,38 @@ fn test_deserialization_requires_rederive() {
     // Serialize
     let json = serde_json::to_string(&identity).expect("Serialization should succeed");
 
-    // UNSAFE PATH: Direct deserialization (demonstrates the security risk)
-    let mut deserialized_unsafe: ZhtpIdentity = serde_json::from_str(&json)
-        .expect("Deserialization should succeed");
+    // BLOCKED: Direct deserialization is now forbidden
+    let deserialization_result: Result<ZhtpIdentity, _> = serde_json::from_str(&json);
+    assert!(deserialization_result.is_err(),
+        "Direct deserialization should be forbidden");
+    assert!(deserialization_result.unwrap_err().to_string().contains("forbidden"),
+        "Error message should indicate deserialization is forbidden");
 
-    // SECURITY: Secrets should be zero after deserialization
-    assert!(!deserialized_unsafe.is_secrets_derived(),
-        "Secrets should be zero after direct deserialization");
-    assert!(deserialized_unsafe.validate_secrets_derived().is_err(),
-        "Validation should fail for zero secrets");
-
-    // Manual re-derivation (required if using direct deserialization)
+    // SAFE PATH: Using from_serialized helper (enforces re-derivation)
     let private_key = PrivateKey {
         dilithium_sk: vec![1u8; 2528],
         kyber_sk: vec![],
         master_seed: vec![],
     };
-    deserialized_unsafe.rederive_secrets(&private_key)
-        .expect("Rederivation should succeed");
 
-    // Now secrets should be valid
-    assert!(deserialized_unsafe.is_secrets_derived(),
-        "Secrets should be derived after rederive_secrets()");
-    assert!(deserialized_unsafe.validate_secrets_derived().is_ok(),
-        "Validation should pass after rederivation");
-
-    // SAFE PATH: Using from_serialized helper (enforces re-derivation)
-    let deserialized_safe = ZhtpIdentity::from_serialized(&json, &private_key)
+    let deserialized = ZhtpIdentity::from_serialized(&json, &private_key)
         .expect("Safe deserialization should succeed");
 
-    // Secrets should already be derived
-    assert!(deserialized_safe.is_secrets_derived(),
+    // Secrets should be properly derived via new()
+    assert!(deserialized.is_secrets_derived(),
         "Secrets should be derived immediately with from_serialized()");
-    assert!(deserialized_safe.validate_secrets_derived().is_ok(),
+    assert!(deserialized.validate_secrets_derived().is_ok(),
         "Validation should pass for from_serialized()");
 
-    // Verify both paths produce identical results
-    assert_eq!(deserialized_unsafe.did, deserialized_safe.did,
-        "Both paths should produce same DID");
-    assert_eq!(deserialized_unsafe.zk_identity_secret, deserialized_safe.zk_identity_secret,
-        "Both paths should produce same ZK secret");
-    assert_eq!(deserialized_unsafe.zk_credential_hash, deserialized_safe.zk_credential_hash,
-        "Both paths should produce same credential hash");
-    assert_eq!(deserialized_unsafe.wallet_master_seed, deserialized_safe.wallet_master_seed,
-        "Both paths should produce same wallet seed");
+    // Verify derivation matches original
+    assert_eq!(deserialized.did, identity.did,
+        "DID should match original");
+    assert_eq!(deserialized.zk_identity_secret, identity.zk_identity_secret,
+        "ZK secret should match original");
+    assert_eq!(deserialized.zk_credential_hash, identity.zk_credential_hash,
+        "Credential hash should match original");
+    assert_eq!(deserialized.wallet_master_seed, identity.wallet_master_seed,
+        "Wallet seed should match original");
 }
 
 // GOLDEN VECTOR TEST: Validate deterministic derivation with expected outputs
@@ -315,18 +304,43 @@ fn test_deterministic_derivation_golden_vector() {
         master_seed: vec![],
     };
 
-    // Expected outputs for all-zero keys (precomputed with blake3)
-    // DID = "did:zhtp:" + hex(blake3(vec![0u8; 1312]))
+    // Expected outputs for all-zero keys (computed per spec, not via derive functions)
     let expected_did_zeros = {
-        let hash = lib_crypto::hash_blake3(&vec![0u8; 1312]);
-        format!("did:zhtp:{}", hex::encode(hash))
+        let hash = blake3::hash(&public_key_zeros.dilithium_pk);
+        format!("did:zhtp:{}", hash.to_hex())
     };
 
-    // Expected ZK secret = blake3("ZHTP_ZK_SECRET_V1:" + vec![0u8; 2528])
     let expected_zk_secret_zeros = {
-        let mut data = b"ZHTP_ZK_SECRET_V1:".to_vec();
-        data.extend_from_slice(&vec![0u8; 2528]);
-        lib_crypto::hash_blake3(&data)
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"ZHTP_ZK_SECRET_V1:");
+        hasher.update(&private_key_zeros.dilithium_sk);
+        hasher.finalize()
+    };
+
+    let expected_zk_cred_hash_zeros = {
+        let age_val: u64 = 30;
+        let juris_code: u64 = 840; // US
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"ZHTP_CREDENTIAL_V1:");
+        hasher.update(expected_zk_secret_zeros.as_bytes());
+        hasher.update(&age_val.to_le_bytes());
+        hasher.update(&juris_code.to_le_bytes());
+        hasher.finalize()
+    };
+
+    let expected_wallet_seed_zeros = {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"ZHTP_WALLET_SEED_V1:");
+        hasher.update(&private_key_zeros.dilithium_sk);
+        let mut reader = hasher.finalize_xof();
+        let mut out = [0u8; 64];
+        reader.fill(&mut out);
+        out
+    };
+
+    let expected_dao_member_id_zeros = {
+        let hash = blake3::hash(format!("DAO:{}", expected_did_zeros).as_bytes());
+        hash.to_hex().to_string()
     };
 
     let ownership_proof = ZeroKnowledgeProof {
@@ -355,8 +369,14 @@ fn test_deterministic_derivation_golden_vector() {
     assert_eq!(identity_zeros.did.len(), 73, "DID should be 73 chars (did:zhtp: + 64 hex)");
 
     // Validate ZK secret derivation
-    assert_eq!(identity_zeros.zk_identity_secret, expected_zk_secret_zeros,
+    assert_eq!(identity_zeros.zk_identity_secret, *expected_zk_secret_zeros.as_bytes(),
         "ZK secret should match expected hash for zero keys");
+    assert_eq!(identity_zeros.zk_credential_hash, *expected_zk_cred_hash_zeros.as_bytes(),
+        "ZK credential hash should match expected hash for zero keys");
+    assert_eq!(identity_zeros.wallet_master_seed, expected_wallet_seed_zeros,
+        "Wallet seed should match expected XOF output for zero keys");
+    assert_eq!(identity_zeros.dao_member_id, expected_dao_member_id_zeros,
+        "DAO member ID should match expected hash for zero keys");
 
     // Test vector 2: Non-zero pattern (validates different inputs produce different outputs)
     let public_key_pattern = PublicKey {

--- a/tests/zhtp_identity_fields.rs
+++ b/tests/zhtp_identity_fields.rs
@@ -16,24 +16,30 @@ use std::collections::HashMap;
 //       dao_member_id, dao_voting_power, citizenship_verified, jurisdiction
 #[test]
 fn test_zhtp_identity_has_required_fields() {
-    let node_id = NodeId::from_did_device("did:zhtp:test123", "laptop")
-        .expect("Valid NodeId");
-
-    let mut device_node_ids = HashMap::new();
-    device_node_ids.insert("laptop".to_string(), node_id);
-
     let identity = create_test_identity();
 
-    // Verify all new fields are accessible
-    assert_eq!(identity.did, "did:zhtp:test123");
+    // Verify all new fields are accessible and properly derived
+    // DID should be derived from public key (not hardcoded)
+    assert!(identity.did.starts_with("did:zhtp:"));
+    assert_eq!(identity.did.len(), 73); // "did:zhtp:" + 64 hex chars
+
     assert_eq!(identity.primary_device, "laptop");
-    assert_eq!(identity.dao_voting_power, 100);
+
+    // DAO voting power should be 10 for verified citizens (from new() logic)
+    assert_eq!(identity.dao_voting_power, 10);
     assert_eq!(identity.citizenship_verified, true);
     assert_eq!(identity.jurisdiction, Some("US".to_string()));
     assert_eq!(identity.device_node_ids.len(), 1);
+
+    // Secrets should be derived (non-zero) from private key
     assert_eq!(identity.zk_identity_secret.len(), 32);
+    assert_ne!(identity.zk_identity_secret, [0u8; 32], "zk_identity_secret should not be zero");
+
     assert_eq!(identity.zk_credential_hash.len(), 32);
+    assert_ne!(identity.zk_credential_hash, [0u8; 32], "zk_credential_hash should not be zero");
+
     assert_eq!(identity.wallet_master_seed.len(), 64);
+    assert_ne!(identity.wallet_master_seed, [0u8; 64], "wallet_master_seed should not be zero");
 }
 
 // AC2: Correct types from lib-crypto
@@ -67,8 +73,8 @@ fn test_private_key_not_serialized() {
     assert!(!json.contains("private_key"),
             "private_key should be skipped in serialization");
 
-    // Verify did IS in JSON (sanity check)
-    assert!(json.contains("did:zhtp:test123"),
+    // Verify did IS in JSON (sanity check) - check for the prefix since DID is derived
+    assert!(json.contains("did:zhtp:"),
             "did should be present in serialization");
 }
 
@@ -180,55 +186,40 @@ fn test_citizenship_fields() {
     assert_eq!(identity.jurisdiction, None);
 }
 
-// Helper function to create test identity
+// Helper function to create test identity using proper new() constructor
+// This ensures all cryptographic fields are derived correctly per spec
 fn create_test_identity() -> ZhtpIdentity {
-    let node_id = NodeId::from_did_device("did:zhtp:test123", "laptop")
-        .expect("Valid NodeId");
+    // Use a real-ish keypair for testing (deterministic for repeatability)
+    let public_key = PublicKey::new(vec![42u8; 64]);
+    let private_key = PrivateKey {
+        dilithium_sk: vec![1u8; 32],
+        kyber_sk: vec![],
+        master_seed: vec![],
+    };
 
-    let mut device_node_ids = HashMap::new();
-    device_node_ids.insert("laptop".to_string(), node_id);
+    let ownership_proof = ZeroKnowledgeProof {
+        proof_system: "test".to_string(),
+        proof_data: vec![],
+        public_inputs: vec![],
+        verification_key: vec![],
+        plonky2_proof: None,
+        proof: vec![],
+    };
 
-    ZhtpIdentity {
-        id: lib_crypto::Hash::from_bytes(&[0u8; 32]),
-        identity_type: IdentityType::Human,
-        did: "did:zhtp:test123".to_string(),
-        public_key: PublicKey::new(vec![1u8; 64]),
-        private_key: None,
-        node_id,
-        device_node_ids,
-        primary_device: "laptop".to_string(),
-        zk_identity_secret: [0u8; 32],
-        zk_credential_hash: [0u8; 32],
-        wallet_master_seed: [0u8; 64],
-        dao_member_id: "dao_member_123".to_string(),
-        dao_voting_power: 100,
-        citizenship_verified: true,
-        jurisdiction: Some("US".to_string()),
-        age: Some(30u64),
-        reputation: 1000u64,
-        created_at: 0,
-        last_active: 0,
-        recovery_keys: vec![],
-        did_document_hash: None,
-        owner_identity_id: None,
-        reward_wallet_id: None,
-        encrypted_master_seed: None,
-        next_wallet_index: 0,
-        password_hash: None,
-        master_seed_phrase: None,
-        attestations: vec![],
-        wallet_manager: WalletManager::new(lib_crypto::Hash::from_bytes(&[0u8; 32])),
-        ownership_proof: ZeroKnowledgeProof {
-            proof_system: "test".to_string(),
-            proof_data: vec![],
-            public_inputs: vec![],
-            verification_key: vec![],
-            plonky2_proof: None,
-            proof: vec![],
-        },
-        access_level: AccessLevel::default(),
-        metadata: std::collections::HashMap::new(),
-        credentials: std::collections::HashMap::new(),
-        private_data_id: None,
-    }
+    // Use new() to get proper derivation of all fields
+    let mut identity = ZhtpIdentity::new(
+        IdentityType::Human,
+        public_key,
+        private_key,
+        "laptop".to_string(),
+        Some(30u64),
+        Some("US".to_string()),
+        true,  // Verified citizen for testing
+        ownership_proof,
+    ).expect("Failed to create test identity");
+
+    // Override reputation for testing (in real usage, this would be managed separately)
+    identity.reputation = 1000u64;
+
+    identity
 }


### PR DESCRIPTION
## Summary

Implements P1-5: Adds DID, NodeId, device management, and cryptographic secret fields to ZhtpIdentity struct per architecture specification.

## Changes

### New Fields Added
- `did: String` - Decentralized Identifier
- `node_id: NodeId` - Primary device NodeId  
- `device_node_ids: HashMap<String, NodeId>` - Multi-device mapping
- `primary_device: String` - Active device name
- `private_key: Option<PrivateKey>` - Private key (not serialized)
- `zk_identity_secret: [u8; 32]` - ZK identity secret
- `zk_credential_hash: [u8; 32]` - ZK credential hash
- `wallet_master_seed: [u8; 64]` - Wallet master seed (raw)
- `dao_member_id: String` - DAO member identifier
- `dao_voting_power: u64` - DAO voting power
- `citizenship_verified: bool` - Citizenship verification status
- `jurisdiction: Option<String>` - Jurisdiction

### Type Corrections
- `public_key: Vec<u8>` → `PublicKey` (lib-crypto type)
- `reputation: u32` → `u64` (spec alignment)
- `age: Option<u8>` → `Option<u64>` (spec alignment)

### Migration Support
- Added `ZhtpIdentity::from_legacy_fields()` helper constructor
- Added `Default` impl for `NodeId`
- Added serde defaults for all new fields
- Updated all existing struct initializers across codebase

### System-wide Updates
- Fixed ~15 call sites to use `public_key.as_bytes()`
- Updated `ReputationBreakdown` fields to u64
- Updated `IdentityProofParams.min_reputation` to u64
- Fixed manager.rs, lib.rs, DID generation, proofs, verification

## Test Coverage

All 8 acceptance criteria tests passing:
- ✅ New fields present and accessible
- ✅ Correct lib-crypto types used
- ✅ private_key serialization skipped
- ✅ Type corrections applied (age, reputation)
- ✅ Multi-device HashMap works
- ✅ Fixed-size arrays for secrets
- ✅ DAO fields present
- ✅ Citizenship fields present

## Dependencies
- Requires: P1-1 (NodeId struct) ✅
- Requires: P1-3 (Type exports) ✅
- Blocks: P1-6, P1-7, P1-8, P1-13, P1-14

## Architecture Alignment
Fully aligns with `ARCHITECTURE_CONSOLIDATION.md` specification for ZhtpIdentity unified structure.